### PR TITLE
feat: add portable visual style companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - 基于证据的简历内容核验，禁止虚构指标、经历和技能。
 - Taste 风格的创意版式词汇与开放视觉探索。
 - 离线 UI/UX 设计目录、媒体艺术指导和参考图工作流。
+- 内置 Visual Companion：无需 Codex Browser 插件或 npm 安装，在系统浏览器中并排展示 2–3 个视觉方向，最终选择与批准只在 conversation 中完成。
 - 经用户明确授权后使用多 Agent，并通过文件所有权避免并行冲突。
 - 截图审查、响应式修复、可访问性检查和安全动效。
 - 可选 APIHz 媒体搜索、本地 Poster 和视频升级。
@@ -47,6 +48,24 @@ $resume-portfolio-workflow
 也可以在边界明确时单独调用内容或网站 Skill。网站 Skill 检测到内容包缺失或需要事实修改时，会要求先执行内容核验流程。
 
 插件清单位于 `.codex-plugin/plugin.json`。
+
+## 跨 Agent 视觉预览
+
+网站 Skill 自带纯 Node.js Visual Companion，只使用 Node 内置模块。它生成
+display-only 本地画廊，默认监听 `127.0.0.1`，并返回带随机会话密钥的完整
+URL。浏览器不会提交选择；用户必须回到 conversation 明确批准。
+
+支持具备 Node.js、Shell、文件系统和浏览器访问路径的本地 coding agent：
+
+- Codex：使用可持续运行或异步终端命令；
+- Claude Code：使用后台 Shell 任务；
+- Cursor：使用其终端后台任务；
+- Copilot CLI：使用异步 Shell；
+- 其他本地 Agent：保持前台服务器进程，或直接展示静态 HTML。
+
+自动打开浏览器失败时继续提供 URL；服务器不能存活或远程 loopback
+不可访问时，保留并展示静态 `gallery.html`。远程场景只使用用户已授权的
+端口转发，不上传简历或视觉稿。
 
 ## 安全边界
 

--- a/docs/superpowers/plans/2026-07-31-portable-visual-style-companion.md
+++ b/docs/superpowers/plans/2026-07-31-portable-visual-style-companion.md
@@ -1,0 +1,753 @@
+# Portable Visual Style Companion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dependency-free, cross-platform, display-only local visual gallery to the website-design approval gate.
+
+**Architecture:** A small CommonJS server serves one generated gallery from a token-protected loopback URL. Cross-platform launch and stop commands manage exact session directories, while the Skill contract and site-design schema require the user to approve a displayed candidate in the conversation before implementation planning.
+
+**Tech Stack:** Node.js built-in modules, Python 3 standard library, JSON Schema documentation, Python `unittest`.
+
+## Global Constraints
+
+- Use only Node.js built-in modules; do not require `npm install`.
+- Bind to `127.0.0.1` by default and authenticate every request with a random session key.
+- Accept only `GET` and `HEAD`; do not add WebSockets, forms, uploads, proxies, or browser event collection.
+- Treat the browser as display-only; approval is valid only when `approval_channel` is `conversation`.
+- Keep generated galleries under `.resume-site-work/style-preview/sessions/`.
+- Never create or edit `.resume-site-work/site` during visual style comparison.
+- Preserve a standalone `gallery.html` fallback when automatic opening or server lifetime fails.
+- Implement original minimal code; do not copy the external Brainstorming Visual Companion.
+- Advance full site-design specifications to schema version 2; do not infer or migrate approval from version 1.
+
+## File Map
+
+- Create `skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs`: authenticated read-only static server.
+- Create `skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs`: session creation, server lifecycle, and optional system-browser launch.
+- Create `skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs`: exact-session process termination with path containment checks.
+- Create `skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html`: standalone display-only gallery starting point.
+- Create `skills/build-resume-portfolio-site/references/visual-style-preview-contract.md`: agent-facing generation and fallback protocol.
+- Create `tests/test_visual_companion.py`: process, HTTP, security, fallback, and stop tests.
+- Modify `skills/build-resume-portfolio-site/references/site-design-spec-schema.json`: document schema version 2 and `visual_preview`.
+- Modify `skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py`: enforce conversational approval and gallery containment.
+- Modify `tests/fixtures/site-design-spec-valid.json`: valid version-2 full-workflow fixture.
+- Modify `tests/test_workflow_behavior_contract.py`: rejection cases for missing or browser-derived approval.
+- Modify `skills/build-resume-portfolio-site/scripts/validate_skill_resources.py`: package and discovery-resource checks.
+- Modify `skills/build-resume-portfolio-site/SKILL.md`: insert visual-preview transaction before site-design approval.
+- Modify `skills/build-resume-portfolio-site/references/site-brainstorming-contract.md`: require display of two or three directions.
+- Modify `skills/build-resume-portfolio-site/references/artifact-layout.md`: record style-preview ownership and lifecycle.
+- Modify `README.md`: document dependency-free browser presentation and conversational approval.
+
+---
+
+### Task 1: Enforce the Version-2 Visual Preview Approval Contract
+
+**Files:**
+
+- Modify: `tests/fixtures/site-design-spec-valid.json`
+- Modify: `tests/test_workflow_behavior_contract.py`
+- Modify: `skills/build-resume-portfolio-site/references/site-design-spec-schema.json`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py`
+
+**Interfaces:**
+
+- Consumes: existing `validate(payload: Any) -> list[str]`.
+- Produces: version-2 `visual_preview` with candidate IDs aligned to `alternatives`.
+
+- [ ] **Step 1: Add failing validator tests**
+
+Add a valid fixture field:
+
+```json
+"visual_preview": {
+  "mode": "local-gallery",
+  "artifact": ".resume-site-work/style-preview/sessions/style-1/gallery.html",
+  "candidate_ids": ["editorial", "cinematic"],
+  "recommended_candidate_id": "editorial",
+  "selected_candidate_id": "editorial",
+  "approval_channel": "conversation",
+  "explicitly_approved": true
+}
+```
+
+Change `schema_version` to `2`, then add tests:
+
+```python
+def test_full_site_requires_visual_preview(self) -> None:
+    result = self.run_validator(
+        "build-resume-portfolio-site",
+        "validate_site_design_spec.py",
+        "site-design-spec-valid.json",
+        lambda payload: payload.pop("visual_preview"),
+    )
+    self.assertNotEqual(result.returncode, 0)
+
+def test_browser_activity_cannot_approve_site_design(self) -> None:
+    result = self.run_validator(
+        "build-resume-portfolio-site",
+        "validate_site_design_spec.py",
+        "site-design-spec-valid.json",
+        lambda payload: payload["visual_preview"].update(
+            {"approval_channel": "browser"}
+        ),
+    )
+    self.assertNotEqual(result.returncode, 0)
+
+def test_version_one_site_design_is_rejected(self) -> None:
+    result = self.run_validator(
+        "build-resume-portfolio-site",
+        "validate_site_design_spec.py",
+        "site-design-spec-valid.json",
+        lambda payload: payload.update({"schema_version": 1}),
+    )
+    self.assertNotEqual(result.returncode, 0)
+```
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run:
+
+```powershell
+python -m unittest tests.test_workflow_behavior_contract -v
+```
+
+Expected: the new version-2 fixture or rejection tests fail because the validator still accepts schema version 1 and ignores `visual_preview`.
+
+- [ ] **Step 3: Implement version-2 validation**
+
+Add `visual_preview` to the schema documentation and validate it only when
+`workflow_mode == "full"`:
+
+```python
+def _validate_visual_preview(
+    preview: Any,
+    alternative_ids: list[str],
+) -> list[str]:
+    if not isinstance(preview, dict):
+        return ["full mode requires visual_preview"]
+    required = {
+        "mode",
+        "artifact",
+        "candidate_ids",
+        "recommended_candidate_id",
+        "selected_candidate_id",
+        "approval_channel",
+        "explicitly_approved",
+    }
+    errors = [
+        f"visual_preview missing field: {name}"
+        for name in sorted(required - set(preview))
+    ]
+    if errors:
+        return errors
+    candidate_ids = preview["candidate_ids"]
+    if (
+        not isinstance(candidate_ids, list)
+        or not 2 <= len(candidate_ids) <= 3
+        or not all(isinstance(item, str) and item.strip() for item in candidate_ids)
+        or len(candidate_ids) != len(set(candidate_ids))
+    ):
+        errors.append("visual_preview candidate_ids must contain two or three unique IDs")
+        candidate_ids = []
+    if set(candidate_ids) != set(alternative_ids):
+        errors.append("visual_preview candidate_ids must match alternatives")
+    if preview["mode"] != "local-gallery":
+        errors.append("visual_preview mode must be local-gallery")
+    artifact = str(preview["artifact"]).replace("\\", "/")
+    prefix = ".resume-site-work/style-preview/sessions/"
+    if not artifact.startswith(prefix) or not artifact.endswith("/gallery.html"):
+        errors.append("visual_preview artifact must be a session gallery")
+    for key in ("recommended_candidate_id", "selected_candidate_id"):
+        if preview[key] not in candidate_ids:
+            errors.append(f"visual_preview {key} must reference a candidate")
+    if preview["approval_channel"] != "conversation":
+        errors.append("visual_preview approval_channel must be conversation")
+    if preview["explicitly_approved"] is not True:
+        errors.append("visual_preview must be explicitly approved")
+    return errors
+```
+
+Set the active schema constant to `2`, call this helper after collecting
+alternative IDs, and keep fast-change mode exempt from the preview object.
+
+- [ ] **Step 4: Run tests and verify success**
+
+Run:
+
+```powershell
+python -m unittest tests.test_workflow_behavior_contract -v
+python skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py tests/fixtures/site-design-spec-valid.json
+```
+
+Expected: all behavior tests pass and the validator prints
+`OK: site design spec is valid`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- tests/fixtures/site-design-spec-valid.json tests/test_workflow_behavior_contract.py skills/build-resume-portfolio-site/references/site-design-spec-schema.json skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
+git commit -m "feat: require conversational visual preview approval"
+```
+
+### Task 2: Build the Authenticated Read-Only Gallery Server
+
+**Files:**
+
+- Create: `tests/test_visual_companion.py`
+- Create: `skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs`
+
+**Interfaces:**
+
+- Consumes: `--session-dir`, `--gallery`, optional `--host`, `--port`, and `--token`.
+- Produces: one-line JSON `{type, pid, port, host, url, session_dir, gallery}` and an HTTP server that serves only the session gallery and assets.
+
+- [ ] **Step 1: Add failing HTTP and security tests**
+
+Create a test harness that starts Node, reads the first stdout line, and uses
+`urllib.request`:
+
+```python
+class VisualCompanionServerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.session = Path(self.temp.name)
+        self.gallery = self.session / "gallery.html"
+        self.gallery.write_text("<!doctype html><h1>Directions</h1>", encoding="utf-8")
+        command = [
+            "node",
+            str(SERVER),
+            "--session-dir", str(self.session),
+            "--gallery", str(self.gallery),
+            "--port", "0",
+            "--token", "test-token-1234567890",
+        ]
+        self.process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.info = json.loads(self.process.stdout.readline())
+
+    def tearDown(self) -> None:
+        self.process.terminate()
+        self.process.wait(timeout=5)
+        self.temp.cleanup()
+
+    def test_authenticated_get_serves_gallery(self) -> None:
+        with urllib.request.urlopen(self.info["url"], timeout=3) as response:
+            self.assertEqual(response.status, 200)
+            self.assertIn(b"Directions", response.read())
+            self.assertEqual(response.headers["Cache-Control"], "no-store")
+
+    def test_missing_key_is_forbidden(self) -> None:
+        url = f'http://127.0.0.1:{self.info["port"]}/'
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            urllib.request.urlopen(url, timeout=3)
+        self.assertEqual(caught.exception.code, 403)
+
+    def test_post_is_rejected(self) -> None:
+        request = urllib.request.Request(
+            self.info["url"], data=b"x", method="POST"
+        )
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            urllib.request.urlopen(request, timeout=3)
+        self.assertEqual(caught.exception.code, 405)
+```
+
+Add tests for `HEAD`, wrong keys, traversal, unsupported extensions, loopback
+default binding, and all required security headers.
+
+- [ ] **Step 2: Run the server tests and verify failure**
+
+Run:
+
+```powershell
+python -m unittest tests.test_visual_companion -v
+```
+
+Expected: FAIL because `server.cjs` does not exist.
+
+- [ ] **Step 3: Implement the minimal server**
+
+Implement argument parsing, canonical path containment, constant-time token
+comparison, MIME lookup, `GET`/`HEAD`, and startup JSON using:
+
+```javascript
+const crypto = require("crypto");
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+
+const MIME = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
+  [".js", "application/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".webp", "image/webp"],
+  [".gif", "image/gif"],
+]);
+
+function safeEqual(left, right) {
+  const a = Buffer.from(String(left));
+  const b = Buffer.from(String(right));
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function inside(root, target) {
+  const relative = path.relative(root, target);
+  return relative === "" || (
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== ".." &&
+    !path.isAbsolute(relative)
+  );
+}
+```
+
+Reject symlinks and non-regular files, emit stable JSON errors to stderr, set
+the authentication cookie after a valid query-key request, and close cleanly
+on `SIGINT` or `SIGTERM`.
+
+- [ ] **Step 4: Run tests and syntax checks**
+
+Run:
+
+```powershell
+node --check skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
+python -m unittest tests.test_visual_companion.VisualCompanionServerTests -v
+```
+
+Expected: Node syntax check exits `0`; all server tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- tests/test_visual_companion.py skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
+git commit -m "feat: add read-only visual gallery server"
+```
+
+### Task 3: Add Cross-Platform Launch and Exact-Session Stop Commands
+
+**Files:**
+
+- Modify: `tests/test_visual_companion.py`
+- Create: `skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs`
+- Create: `skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs`
+
+**Interfaces:**
+
+- Consumes: `launch.cjs --workspace-root <path> --gallery <path> [--open] [--foreground]`.
+- Produces: startup JSON containing `server_info` and
+  `.resume-site-work/style-preview/sessions/<id>/state/server-info.json`.
+- Consumes: `stop.cjs --workspace-root <path> --server-info <path>`.
+- Produces: JSON `{type:"server-stopped", pid, session_dir}` without deleting artifacts.
+
+- [ ] **Step 1: Add failing lifecycle tests**
+
+Add tests that:
+
+```python
+def test_launch_creates_contained_session_and_server_info(self) -> None:
+    result = self.launch()
+    info = json.loads(result.stdout.splitlines()[0])
+    session = Path(info["session_dir"]).resolve()
+    expected = (
+        self.workspace
+        / ".resume-site-work"
+        / "style-preview"
+        / "sessions"
+    ).resolve()
+    self.assertTrue(session.is_relative_to(expected))
+    self.assertTrue((session / "state" / "server-info.json").is_file())
+
+def test_open_failure_does_not_stop_server(self) -> None:
+    result = self.launch(
+        extra_env={"VISUAL_COMPANION_OPEN_COMMAND": "__missing_command__"},
+        open_browser=True,
+    )
+    info = json.loads(result.stdout.splitlines()[0])
+    with urllib.request.urlopen(info["url"], timeout=3) as response:
+        self.assertEqual(response.status, 200)
+
+def test_stop_rejects_server_info_outside_workspace(self) -> None:
+    result = subprocess.run(
+        [
+            "node", str(STOP),
+            "--workspace-root", str(self.workspace),
+            "--server-info", str(self.workspace / "outside.json"),
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    self.assertNotEqual(result.returncode, 0)
+```
+
+Also assert that stop terminates the recorded process and preserves
+`gallery.html`.
+
+- [ ] **Step 2: Run lifecycle tests and verify failure**
+
+Run:
+
+```powershell
+python -m unittest tests.test_visual_companion.VisualCompanionLifecycleTests -v
+```
+
+Expected: FAIL because launch and stop commands do not exist.
+
+- [ ] **Step 3: Implement launch and browser-open isolation**
+
+Use `spawn` with argument arrays and platform launchers:
+
+```javascript
+function browserCommand(url) {
+  if (process.env.VISUAL_COMPANION_OPEN_COMMAND) {
+    return {
+      command: process.env.VISUAL_COMPANION_OPEN_COMMAND,
+      args: [url],
+    };
+  }
+  if (process.platform === "win32") {
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Start-Process -FilePath $args[0]",
+        url,
+      ],
+    };
+  }
+  if (process.platform === "darwin") return {command: "open", args: [url]};
+  return {command: "xdg-open", args: [url]};
+}
+```
+
+Create the session with `fs.mkdtempSync`, copy the supplied gallery and its
+optional `assets` sibling into it, generate a 32-byte token, and pass the token
+to `server.cjs`. Write server info atomically using a temporary file plus
+`renameSync`.
+
+Foreground mode inherits server lifetime. Default mode detaches the child,
+waits for its startup JSON, persists server info, and exits. An open failure
+adds an `open_warning` to startup output but does not stop the server.
+
+- [ ] **Step 4: Implement exact-session stop**
+
+Resolve the workspace sessions root and server-info path, require containment,
+parse an integer PID, and call `process.kill(pid, "SIGTERM")`. Refuse missing,
+malformed, outside-root, or PID-mismatched records. Do not delete the session.
+
+- [ ] **Step 5: Run lifecycle and syntax tests**
+
+Run:
+
+```powershell
+node --check skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs
+node --check skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs
+python -m unittest tests.test_visual_companion -v
+```
+
+Expected: all syntax and lifecycle checks pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add -- tests/test_visual_companion.py skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs
+git commit -m "feat: manage portable visual preview sessions"
+```
+
+### Task 4: Package the Display-Only Gallery and Validate Its Resources
+
+**Files:**
+
+- Create: `skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html`
+- Create: `skills/build-resume-portfolio-site/references/visual-style-preview-contract.md`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_skill_resources.py`
+- Modify: `tests/test_workflow_behavior_contract.py`
+- Modify: `tests/test_visual_companion.py`
+
+**Interfaces:**
+
+- Consumes: approved copy, authorized local media, and two or three alternative IDs.
+- Produces: standalone `gallery.html` with no controls, forms, or approval semantics.
+
+- [ ] **Step 1: Add failing package and static fallback tests**
+
+Add:
+
+```python
+def test_visual_companion_resources_are_packaged(self) -> None:
+    root = ROOT / "skills" / "build-resume-portfolio-site"
+    required = (
+        "assets/visual-companion/gallery-shell.html",
+        "references/visual-style-preview-contract.md",
+        "scripts/visual_companion/server.cjs",
+        "scripts/visual_companion/launch.cjs",
+        "scripts/visual_companion/stop.cjs",
+    )
+    for relative in required:
+        self.assertTrue((root / relative).is_file(), relative)
+
+def test_gallery_shell_is_display_only(self) -> None:
+    text = GALLERY_SHELL.read_text(encoding="utf-8").lower()
+    self.assertNotIn("<form", text)
+    self.assertNotIn("data-choice", text)
+    self.assertIn("approve in the conversation", text)
+```
+
+Run the skeleton resource validator in a temporary copied Skill with each new
+resource removed once and assert `missing_contract` or
+`missing_visual_companion` is reported.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+python -m unittest tests.test_visual_companion tests.test_workflow_behavior_contract -v
+```
+
+Expected: resource and gallery-shell tests fail.
+
+- [ ] **Step 3: Add the gallery shell and preview contract**
+
+Create a responsive shell containing:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Portfolio visual directions</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+    body { margin: 0; background: #111; color: #f5f5f5; }
+    main { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 32px 0 64px; }
+    .directions { display: grid; gap: 24px; }
+    .direction { border: 1px solid #444; border-radius: 18px; overflow: hidden; }
+    .notice { padding: 14px 18px; background: #f0cf5b; color: #18140a; }
+    @media (max-width: 720px) { main { width: min(100% - 20px, 1440px); } }
+  </style>
+</head>
+<body>
+  <p class="notice">Review the directions here, then approve in the conversation.</p>
+  <main>
+    <!-- Replace this comment with two or three complete direction sections. -->
+  </main>
+</body>
+</html>
+```
+
+The contract must define candidate IDs, real-content use, desktop/mobile
+framing, no browser approval, server commands, static fallback, process
+lifetime by agent class, and cleanup.
+
+- [ ] **Step 4: Register discovery resources**
+
+Add these resources:
+
+```python
+CONTRACT_SPECS.update({
+    "visual-style-preview-contract":
+        "references/visual-style-preview-contract.md",
+})
+
+VISUAL_COMPANION_FILES = (
+    "assets/visual-companion/gallery-shell.html",
+    "scripts/visual_companion/server.cjs",
+    "scripts/visual_companion/launch.cjs",
+    "scripts/visual_companion/stop.cjs",
+)
+```
+
+Include the contract and files in `discovery` and `skeleton` validation.
+Return `missing_visual_companion: <relative-path>` for absent files.
+
+- [ ] **Step 5: Run resource and standalone rendering tests**
+
+Run:
+
+```powershell
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode skeleton
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage discovery
+python -m unittest tests.test_visual_companion tests.test_workflow_behavior_contract -v
+```
+
+Expected: both resource reports have `"ok": true`; tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html skills/build-resume-portfolio-site/references/visual-style-preview-contract.md skills/build-resume-portfolio-site/scripts/validate_skill_resources.py tests/test_visual_companion.py tests/test_workflow_behavior_contract.py
+git commit -m "feat: package display-only style gallery"
+```
+
+### Task 5: Integrate the Preview Transaction into the Skill Workflow
+
+**Files:**
+
+- Modify: `skills/build-resume-portfolio-site/SKILL.md`
+- Modify: `skills/build-resume-portfolio-site/references/site-brainstorming-contract.md`
+- Modify: `skills/build-resume-portfolio-site/references/artifact-layout.md`
+- Modify: `README.md`
+- Modify: `tests/test_workflow_behavior_contract.py`
+
+**Interfaces:**
+
+- Consumes: validated discovery resources and candidate alternatives.
+- Produces: displayed gallery plus conversation-approved version-2 site design spec.
+
+- [ ] **Step 1: Add failing workflow text tests**
+
+Add:
+
+```python
+def test_site_discovery_requires_display_only_visual_gallery(self) -> None:
+    text = self.read_skill("build-resume-portfolio-site").lower()
+    self.assertIn("visual-style-preview-contract.md", text)
+    self.assertIn("approval remains in the conversation", text)
+    self.assertIn("launch.cjs", text)
+    self.assertIn("do not edit react source", text)
+
+def test_browser_activity_never_counts_as_approval(self) -> None:
+    contract = (
+        ROOT / "skills" / "build-resume-portfolio-site"
+        / "references" / "site-brainstorming-contract.md"
+    ).read_text(encoding="utf-8").lower()
+    self.assertIn("browser activity never counts as approval", contract)
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+python -m unittest tests.test_workflow_behavior_contract -v
+```
+
+Expected: the new workflow wording tests fail.
+
+- [ ] **Step 3: Update the discovery sequence**
+
+In `SKILL.md`, require:
+
+```text
+candidate alternatives
+-> gallery.html generated outside site/
+-> launch.cjs invoked with the workspace root
+-> complete URL and static file path shown
+-> user selects in conversation
+-> version-2 site-design-spec.json written and validated
+-> user explicitly approves in conversation
+-> implementation plan written
+```
+
+State that automatic-open failure is non-blocking, server failure uses the
+static file, remote loopback requires an existing authorized port forward, and
+browser activity never advances state.
+
+Update the brainstorming contract and artifact layout with the same ownership
+and lifecycle boundaries. Update README usage examples for Codex, Claude Code,
+Cursor, Copilot CLI, and generic local agents without claiming support where
+Node, shell, filesystem, or browser routing is absent.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run:
+
+```powershell
+python -m unittest tests.test_workflow_behavior_contract tests.test_visual_companion -v
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode skeleton
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage discovery
+```
+
+Expected: all tests pass and both resource validations succeed.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/SKILL.md skills/build-resume-portfolio-site/references/site-brainstorming-contract.md skills/build-resume-portfolio-site/references/artifact-layout.md README.md tests/test_workflow_behavior_contract.py
+git commit -m "docs: integrate visual preview approval gate"
+```
+
+### Task 6: End-to-End Smoke Test and Installed-Copy Verification
+
+**Files:**
+
+- Modify only if a defect is found: files introduced or changed in Tasks 1–5.
+
+**Interfaces:**
+
+- Consumes: packaged plugin source.
+- Produces: verified local session, static fallback, clean stop, and installable Skill resources.
+
+- [ ] **Step 1: Run all repository tests**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run every Python Skill script test**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_*.py" -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Perform a real local session smoke test**
+
+Create a temporary gallery outside the Skill directory, launch:
+
+```powershell
+$visualLaunch = node skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs --workspace-root "$env:TEMP\resume-visual-smoke" --gallery skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html | ConvertFrom-Json
+```
+
+Use the returned authenticated URL with an HTTP client, confirm status `200`,
+then stop with:
+
+```powershell
+node skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs --workspace-root "$env:TEMP\resume-visual-smoke" --server-info $visualLaunch.server_info
+```
+
+Expected: startup, authenticated request, and exact-session stop succeed;
+`gallery.html` remains; no `.resume-site-work/site` directory exists.
+
+- [ ] **Step 4: Validate Skill structure**
+
+Run:
+
+```powershell
+python C:/Users/86135/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/build-resume-portfolio-site
+git diff --check HEAD~5..HEAD
+git status --short
+```
+
+Expected: Skill validation passes, no whitespace errors, and the source
+repository is clean.
+
+- [ ] **Step 5: Synchronize the verified Skill**
+
+Copy the three verified Skill directories from this plugin source to the
+user's Codex Skill directory only after source verification succeeds. Preserve
+unrelated installed Skills and compare hashes for the modified website Skill.
+Because that destination is outside the workspace, request scoped approval
+before writing it.
+
+- [ ] **Step 6: Verify the installed copy**
+
+Run the installed Skill's resource validator and Node syntax checks from its
+own path. Expected: the installed copy passes the same discovery validation
+and exposes the same file hashes as the source.

--- a/docs/superpowers/specs/2026-07-30-portable-visual-style-companion-design.md
+++ b/docs/superpowers/specs/2026-07-30-portable-visual-style-companion-design.md
@@ -1,0 +1,253 @@
+# Portable Visual Style Companion Design
+
+## Objective
+
+Integrate a self-contained, cross-platform visual style preview into the
+`build-resume-portfolio-site` Skill. During full site discovery, the Skill
+must be able to show two or three materially different visual directions in
+the user's normal browser without depending on the Codex Browser plugin,
+another installed Skill, an MCP server, or an npm install.
+
+The browser is display-only. A click, page visit, or browser-side action never
+counts as approval. The user must select and approve a direction explicitly in
+the conversation.
+
+## Scope
+
+This change adds a local visual gallery and integrates it into the existing
+site-design approval gate. It does not:
+
+- automate or inspect the browser;
+- collect browser events or form submissions;
+- build multiple production React applications;
+- upload resume content or preview artifacts;
+- add an MCP server;
+- change the content-verification workflow;
+- replace the final React, build, screenshot, or confirmation stages.
+
+## User Experience
+
+For a new site or a material visual-direction change:
+
+1. The Skill completes content preflight and decision-bearing discovery.
+2. It defines two or three materially different candidate directions.
+3. It creates a display-only HTML gallery using approved resume content.
+4. It starts a loopback-only local preview server and attempts to open the
+   system browser.
+5. It also prints the complete authenticated URL in the conversation.
+6. The user reviews the candidates and replies in the conversation.
+7. The Skill records the selected candidate and explicit conversational
+   approval in `site-design-spec.json`.
+8. Only then may it create and validate the implementation plan.
+
+If the browser cannot be opened automatically, the user can click the URL. If
+the server cannot remain alive, the Skill provides the generated static HTML
+file as a fallback. The conversation remains the only approval channel in
+every case.
+
+## Architecture
+
+### Skill workflow
+
+`resume-portfolio-workflow` continues to route `site-full` work and does not
+run the preview server itself.
+
+`build-resume-portfolio-site` owns a new visual-preview transaction inside the
+discovery gate:
+
+```text
+candidate definitions
+-> display-only gallery
+-> local preview
+-> conversational selection
+-> validated design specification
+-> explicit conversational approval
+-> implementation plan
+```
+
+Preview artifacts live under:
+
+```text
+.resume-site-work/style-preview/
+  sessions/<session-id>/
+    gallery.html
+    assets/
+    state/
+      server-info.json
+      server.pid
+```
+
+They are discovery artifacts, not React source, confirmed snapshots, or
+publishable site output.
+
+### Portable launcher
+
+The launcher is a CommonJS Node program so Windows, macOS, and Linux agents can
+invoke the same command:
+
+```text
+node <skill-root>/scripts/visual_companion/launch.cjs \
+  --workspace-root <workspace> \
+  [--open] [--foreground]
+```
+
+It:
+
+- requires only Node built-in modules;
+- allocates a random high port unless an explicit port is supplied;
+- binds to `127.0.0.1` by default;
+- creates a random per-session key;
+- writes one JSON startup record to stdout and `server-info.json`;
+- launches the system browser with argument-safe platform commands when
+  `--open` is requested;
+- supports foreground execution for agents that reap detached processes;
+- reports failures as stable JSON error categories.
+
+The stop command accepts an exact session directory or server-info path,
+validates that the resolved target is inside
+`.resume-site-work/style-preview/sessions`, and terminates only the recorded
+process.
+
+### Read-only server
+
+The server exposes only authenticated `GET` and `HEAD` requests. It rejects
+write methods and paths outside the active session directory.
+
+The bootstrap URL contains `?key=<random-token>`. On first load, the server
+stores the key in a same-site, HTTP-only cookie so gallery assets can load
+without exposing the token to page scripts.
+
+Security headers include:
+
+- `Cache-Control: no-store`;
+- `Content-Security-Policy` suitable for local static assets;
+- `X-Content-Type-Options: nosniff`;
+- `X-Frame-Options: DENY`;
+- `Referrer-Policy: no-referrer`;
+- `Cross-Origin-Resource-Policy: same-origin`.
+
+The server has no WebSocket endpoint, event log, form endpoint, upload route,
+directory listing, proxy, or arbitrary filesystem access.
+
+### Gallery document
+
+The Skill writes a complete `gallery.html` using a bundled shell as structural
+guidance. The generated gallery:
+
+- contains two or three candidate directions;
+- uses approved copy and authorized local assets where they materially affect
+  the judgment;
+- gives each candidate a stable ID matching the design specification;
+- shows the visual protagonist, composition, typography, color, density, and
+  one representative interaction state;
+- includes desktop and compact/mobile framing where responsive behavior
+  distinguishes candidates;
+- contains no selection controls or approval buttons;
+- states prominently that approval must be given in the conversation;
+- works as a standalone `file:` document when server startup fails.
+
+Candidate previews may use HTML and CSS mockups, inline SVG, or local raster
+assets. They must not create or modify `.resume-site-work/site`.
+
+## Design Specification Changes
+
+`site-design-spec.json` gains a required `visual_preview` object for full site
+design work:
+
+```json
+{
+  "visual_preview": {
+    "mode": "local-gallery",
+    "artifact": ".resume-site-work/style-preview/sessions/<id>/gallery.html",
+    "candidate_ids": ["direction-a", "direction-b"],
+    "recommended_candidate_id": "direction-b",
+    "selected_candidate_id": "direction-b",
+    "approval_channel": "conversation",
+    "explicitly_approved": true
+  }
+}
+```
+
+The validator enforces:
+
+- two or three unique candidate IDs;
+- recommendation and selection belong to the candidate set;
+- `approval_channel` equals `conversation`;
+- the gallery artifact remains under the style-preview directory;
+- implementation planning cannot proceed while
+  `explicitly_approved` is false.
+
+The active site-design specification schema advances from version 1 to version
+2. Full-workflow version-2 specifications require `visual_preview`;
+fast-change specifications may omit it because they preserve an already
+approved visual direction. Version-1 specifications are rejected and must
+return to discovery rather than being migrated or treated as implicitly
+approved. The repository fixture advances to version 2 with a valid local
+gallery record.
+
+## Agent Compatibility
+
+The Skill documents one portable command and environment-specific process
+lifetime guidance:
+
+- Codex: use a yielded or persistent foreground command;
+- Claude Code and Cursor: use their background shell facility;
+- Copilot CLI: use an asynchronous shell;
+- other local coding agents: keep the foreground process alive or provide the
+  static HTML fallback;
+- remote/container agents: report that loopback may be inaccessible and use
+  an existing user-authorized port-forwarding mechanism when available.
+
+The implementation does not claim compatibility with agents that lack shell
+execution, filesystem access, Node.js, and a route from the user browser to the
+served host.
+
+## Error Handling
+
+Failures are isolated from confirmed artifacts and workflow state:
+
+- `NODE_UNAVAILABLE`: provide the static HTML artifact.
+- `PORT_BIND_FAILED`: retry a bounded number of random ports, then fall back.
+- `OPEN_FAILED`: keep the server active and provide the URL.
+- `SERVER_REAPED`: provide the static HTML artifact and process-lifetime
+  instructions.
+- `UNREACHABLE_REMOTE`: retain the artifact and request an existing
+  user-authorized port-forwarding route.
+- `INVALID_PREVIEW_PATH`: stop without serving files.
+
+No failure may create React source, mark a design approved, advance the build
+stage, or replace the current preview.
+
+## Testing
+
+Automated tests cover:
+
+- startup JSON and server-info generation;
+- authenticated gallery access;
+- rejection of missing or incorrect keys;
+- `GET` and `HEAD` behavior;
+- rejection of write methods and traversal attempts;
+- local-asset MIME types and security headers;
+- loopback default binding;
+- argument-safe browser launcher selection;
+- automatic-open failure isolation;
+- foreground lifecycle and exact-session stop behavior;
+- standalone gallery fallback;
+- validator acceptance of a valid conversational approval;
+- validator rejection of browser-derived or missing approval;
+- Skill behavior contract text and packaged-resource presence.
+
+A manual smoke test starts the server against a temporary workspace, opens the
+gallery URL, verifies desktop and mobile browser rendering, stops the exact
+session, and confirms that no production site or confirmed artifact changed.
+
+## Distribution
+
+All runtime files ship inside the plugin's
+`skills/build-resume-portfolio-site` directory. The Skill resolves them from
+its own `SKILL_ROOT`; it never references a user's global Codex Skill folder or
+the external `brainstorming` Skill.
+
+Before publishing, validate the plugin and installed-copy behavior. The new
+implementation will be original and minimal rather than copying the existing
+Visual Companion source.

--- a/skills/build-resume-portfolio-site/SKILL.md
+++ b/skills/build-resume-portfolio-site/SKILL.md
@@ -10,7 +10,7 @@ Build one directly runnable React + Vite portfolio through four controlled stage
 ## Start or resume
 
 1. Resolve `SKILL_ROOT` as this Skill directory.
-2. Read `references/workflow-contract.md`, `references/artifact-layout.md`, `references/content-preflight-routing-contract.md`, `references/site-brainstorming-contract.md`, `references/site-planning-contract.md`, `references/react-vite-output-contract.md`, `references/reference-library-contract.md`, `references/design-intelligence-contract.md`, `references/creative-direction-contract.md`, and `references/apihz-media-contract.md` completely. When the user explicitly authorizes multi-agent implementation, also read `references/multi-agent-implementation-contract.md` completely before dispatch.
+2. Read `references/workflow-contract.md`, `references/artifact-layout.md`, `references/content-preflight-routing-contract.md`, `references/site-brainstorming-contract.md`, `references/visual-style-preview-contract.md`, `references/site-planning-contract.md`, `references/react-vite-output-contract.md`, `references/reference-library-contract.md`, `references/design-intelligence-contract.md`, `references/creative-direction-contract.md`, and `references/apihz-media-contract.md` completely. When the user explicitly authorizes multi-agent implementation, also read `references/multi-agent-implementation-contract.md` completely before dispatch.
 3. Create `.resume-site-work/` in the active user workspace or load `build-state.json`. The active state schema is version `4`. A version-3 state may be migrated only with `scripts/migrate_build_state.py` into a distinct output file; reject every other old schema and never infer a migration.
 4. Apply content preflight before a new Stage 1 build, when a new resume/JD/claim is supplied, or when the user requests factual/copy changes. Skip it only to resume an existing confirmed site for visual, media, motion, responsive, accessibility, or frontend-only work.
 5. For content preflight, run:
@@ -35,15 +35,27 @@ or implementation-strategy change:
 2. Inspect approved content, authorized media, references, and existing state.
 3. Ask one question at a time; each question must be decision-bearing.
 4. Compare two or three materially different layout or experience families.
-5. Write `.resume-site-work\reports\site-design-spec.json`, validate it with
+5. Follow `references/visual-style-preview-contract.md`. Create one
+   display-only `gallery.html` outside `.resume-site-work\site`; use approved
+   content to show every alternative at the fidelity needed for the decision.
+6. Run `scripts\visual_companion\launch.cjs` with the workspace root and
+   gallery path. Give the user the complete authenticated URL and the absolute
+   static HTML fallback. Automatic-open failure is non-blocking; when the
+   server cannot remain alive, continue with the static file.
+7. Ask the user to select and explicitly approve a candidate in the
+   conversation. Approval remains in the conversation: browser activity,
+   opening the URL, reloads, and screenshots never select a candidate or
+   advance workflow state.
+8. Write schema-version-2
+   `.resume-site-work\reports\site-design-spec.json`, validate it with
    `scripts\validate_site_design_spec.py`, show the recommendation and
-   trade-offs, and wait for explicit user approval.
-6. Validate `planning` resources.
-7. Write `.resume-site-work\reports\site-implementation-plan.json` with exact
+   trade-offs, and preserve the conversational approval evidence.
+9. Validate `planning` resources.
+10. Write `.resume-site-work\reports\site-implementation-plan.json` with exact
    files, dependencies, interfaces, acceptance, verification, rollback, and
    snapshot target. Validate it with
    `scripts\validate_site_implementation_plan.py`.
-8. Select the implementation strategy, then enter Stage 1 or the relevant
+11. Select the implementation strategy, then enter Stage 1 or the relevant
    confirmed-stage transaction.
 
 Do not edit React source before the site design specification is explicitly
@@ -67,7 +79,7 @@ No external Superpowers skill is required at runtime.
 Before each stage, run:
 
 ```powershell
-python "$SKILL_ROOT\scripts\validate_skill_resources.py" --mode runtime --stage <prototype|media-direction|screenshot|motion>
+python "$SKILL_ROOT\scripts\validate_skill_resources.py" --mode runtime --stage <discovery|planning|prototype|media-direction|screenshot|motion>
 ```
 
 Continue only on exit `0`. Exit `2` means approved stage material is unavailable; exit `1` means malformed or missing resources. Report the exact resource and stop instead of substituting a generic prompt, template, or style.

--- a/skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html
+++ b/skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio visual directions</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      background: #101011;
+      color: #f5f4ef;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-width: 320px; background: #101011; }
+    .notice {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      margin: 0;
+      padding: 14px clamp(18px, 4vw, 56px);
+      background: #e9c957;
+      color: #17150e;
+      font-weight: 700;
+      box-shadow: 0 8px 30px rgb(0 0 0 / 30%);
+    }
+    main {
+      width: min(1480px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: clamp(28px, 5vw, 72px) 0 80px;
+    }
+    header { max-width: 780px; margin-bottom: 32px; }
+    h1 { margin: 0 0 12px; font-size: clamp(2rem, 5vw, 4.5rem); }
+    .intro { margin: 0; color: #b7b5ae; font-size: 1.05rem; }
+    .directions { display: grid; gap: 28px; }
+    .direction {
+      overflow: hidden;
+      border: 1px solid #3a3936;
+      border-radius: 22px;
+      background: #19191a;
+      box-shadow: 0 20px 70px rgb(0 0 0 / 24%);
+    }
+    .direction-meta {
+      display: flex;
+      gap: 18px;
+      align-items: baseline;
+      justify-content: space-between;
+      padding: 18px 22px;
+      border-bottom: 1px solid #343330;
+    }
+    .direction-meta h2 { margin: 0; font-size: 1.25rem; }
+    .direction-meta p { margin: 0; color: #aaa79f; }
+    .canvas {
+      min-height: 440px;
+      padding: clamp(20px, 4vw, 52px);
+      background: #222;
+    }
+    .annotation {
+      margin: 0;
+      padding: 18px 22px;
+      color: #c8c6bf;
+      line-height: 1.55;
+    }
+    @media (max-width: 720px) {
+      main { width: min(100% - 20px, 1480px); }
+      .direction-meta { display: block; }
+      .direction-meta p { margin-top: 7px; }
+      .canvas { min-height: 360px; }
+    }
+  </style>
+</head>
+<body>
+  <p class="notice">
+    Review these directions here, then approve in the conversation.
+    This page cannot record or grant approval.
+  </p>
+  <main>
+    <header>
+      <h1>Portfolio visual directions</h1>
+      <p class="intro">
+        Compare composition, hierarchy, typography, color, density, responsive
+        behavior, and the representative interaction state.
+      </p>
+    </header>
+    <div class="directions">
+      <!-- visual-directions -->
+      <article class="direction" data-direction-id="replace-direction-a">
+        <div class="direction-meta">
+          <h2>Replace with direction title</h2>
+          <p>Replace with fit and trade-off summary</p>
+        </div>
+        <div class="canvas">
+          Replace this canvas with a real-content visual mockup.
+        </div>
+        <p class="annotation">
+          Replace with the visual protagonist, composition commitment,
+          type/color character, responsive behavior, and interaction note.
+        </p>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/skills/build-resume-portfolio-site/references/artifact-layout.md
+++ b/skills/build-resume-portfolio-site/references/artifact-layout.md
@@ -9,6 +9,14 @@ Create all generated material under `.resume-site-work/` in the active user work
 |   |-- normalized-resume.json
 |   `-- approved-copy.json
 |-- site/                         # only editable React + Vite source project
+|-- style-preview/                # display-only discovery evidence
+|   |-- drafts/
+|   |   `-- <draft-id>/gallery.html
+|   `-- sessions/
+|       `-- <session-id>/
+|           |-- gallery.html
+|           |-- assets/
+|           `-- state/server-info.json
 |-- versions/
 |   |-- v1-prototype/             # confirmed-source candidates; excludes dist/node_modules
 |   |-- v2-media-direction/
@@ -40,6 +48,12 @@ Create all generated material under `.resume-site-work/` in the active user work
 ```
 
 `site/` is the sole source of truth. Do not maintain a separate HTML version. `preview/dist/` is disposable build output and must be replaced only after source validation and `npm run build` succeed.
+
+`style-preview/` contains display-only discovery evidence. Its galleries are
+not React source, production previews, confirmed snapshots, or publishable
+site output. Browser activity has no approval semantics; only an explicit
+conversation reply may be recorded in the version-2 site design specification.
+Stopping a local session preserves its gallery for review.
 
 The three content files under `input/` plus
 `reports/content-provenance.json` are owned by

--- a/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
+++ b/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
@@ -12,10 +12,20 @@ strategy.
 5. Define the visual protagonist, composition commitment, type/color
    character, representative interaction, fixed constraints, open ceiling,
    and avoid rules.
-6. Write `.resume-site-work/reports/site-design-spec.json`.
-7. Validate it and wait for explicit user approval.
+6. Read `visual-style-preview-contract.md` and create one display-only
+   `gallery.html` that shows all two or three alternatives with approved
+   content. Keep it outside the React source project.
+7. Start the local companion when possible. Always provide the complete
+   authenticated URL and the standalone HTML fallback.
+8. Receive the candidate selection and explicit approval in the conversation.
+   Browser activity never counts as approval and never advances state.
+9. Write schema-version-2
+   `.resume-site-work/reports/site-design-spec.json`.
+10. Validate it before creating the implementation plan.
 
 Do not edit React source before the approved site design specification exists.
+Do not infer approval from a browser visit, screenshot, automatic launch, or
+silence.
 
 Fast change is allowed only with a validated workflow route, a confirmed
 artifact, exact affected files, verification, and rollback baseline. If scope

--- a/skills/build-resume-portfolio-site/references/site-design-spec-schema.json
+++ b/skills/build-resume-portfolio-site/references/site-design-spec-schema.json
@@ -19,7 +19,7 @@
     "approval"
   ],
   "properties": {
-    "schema_version": {"const": 1},
+    "schema_version": {"const": 2},
     "spec_id": {"type": "string", "minLength": 1},
     "workflow_mode": {"enum": ["full", "fast-change"]},
     "content_revision": {"type": "integer", "minimum": 1},
@@ -32,6 +32,45 @@
     "composition_commitment": {"type": "string", "minLength": 1},
     "type_color_character": {"type": "string", "minLength": 1},
     "representative_interaction": {"type": "string", "minLength": 1},
+    "visual_preview": {
+      "type": "object",
+      "required": [
+        "mode",
+        "artifact",
+        "candidate_ids",
+        "recommended_candidate_id",
+        "selected_candidate_id",
+        "approval_channel",
+        "explicitly_approved"
+      ],
+      "properties": {
+        "mode": {"const": "local-gallery"},
+        "artifact": {
+          "type": "string",
+          "pattern": "^\\.resume-site-work/style-preview/sessions/[^/]+/gallery\\.html$"
+        },
+        "candidate_ids": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "recommended_candidate_id": {"type": "string", "minLength": 1},
+        "selected_candidate_id": {"type": "string", "minLength": 1},
+        "approval_channel": {"const": "conversation"},
+        "explicitly_approved": {"const": true}
+      }
+    },
     "approval": {"type": "object"}
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"workflow_mode": {"const": "full"}},
+        "required": ["workflow_mode"]
+      },
+      "then": {"required": ["visual_preview"]}
+    }
+  ]
 }

--- a/skills/build-resume-portfolio-site/references/visual-style-preview-contract.md
+++ b/skills/build-resume-portfolio-site/references/visual-style-preview-contract.md
@@ -1,0 +1,83 @@
+# Visual Style Preview Contract
+
+Use this transaction during full site discovery after defining two or three
+materially different alternatives and before writing an approved site design
+specification.
+
+## Output
+
+Create one complete, standalone UTF-8 document at a new path:
+
+```text
+.resume-site-work/style-preview/drafts/<draft-id>/gallery.html
+```
+
+Use `assets/visual-companion/gallery-shell.html` as structural guidance. The
+gallery contains:
+
+- two or three directions with IDs matching `alternatives`;
+- approved resume copy and only authorized local media;
+- visual protagonist, composition, typography, color, density, and hierarchy;
+- representative interaction state shown visually without executable control;
+- desktop framing and a compact/mobile frame when responsive behavior differs;
+- fit, risk, and responsive trade-offs for each direction;
+- a visible instruction to return to the conversation to select and approve.
+
+The page is display-only. Do not add forms, buttons, `data-choice`, WebSockets,
+event collection, uploads, analytics, or approval controls. Browser activity
+never counts as selection or approval.
+
+Do not create or modify `.resume-site-work/site` while producing the gallery.
+
+## Present
+
+Resolve `SKILL_ROOT` to this Skill directory, then run:
+
+```powershell
+node "$SKILL_ROOT\scripts\visual_companion\launch.cjs" `
+  --workspace-root "." `
+  --gallery ".resume-site-work\style-preview\drafts\<draft-id>\gallery.html" `
+  --open
+```
+
+Read the single startup JSON object. Give the user both:
+
+- the complete authenticated `url`, including its query string;
+- the absolute generated `gallery.html` path as the static fallback.
+
+Automatic opening is best effort. `open_warning: "OPEN_FAILED"` leaves the
+server valid; show the URL. If Node is unavailable, launch fails, the process
+is reaped, or loopback is unreachable, show the standalone HTML path. In a
+remote environment, use only an existing user-authorized port-forwarding
+mechanism; do not publish or upload the gallery.
+
+Process lifetime differs by host. Keep `launch.cjs --foreground` alive through
+the host's asynchronous shell facility when detached processes are reaped.
+
+## Approve
+
+Ask the user to name a candidate in the conversation. After the reply:
+
+1. Record the chosen candidate in `selected_alternative_id` and
+   `visual_preview.selected_candidate_id`.
+2. Set `approval_channel` to `conversation`.
+3. Set `explicitly_approved` to `true` only after an explicit conversational
+   approval.
+4. Write schema-version-2 `reports/site-design-spec.json`.
+5. Validate it before writing the implementation plan.
+
+A browser visit, reload, screenshot, or system-browser launch is not approval.
+
+## Stop
+
+Stop only the exact verified session from the returned `server_info`:
+
+```powershell
+node "$SKILL_ROOT\scripts\visual_companion\stop.cjs" `
+  --workspace-root "." `
+  --server-info "<returned-server-info-path>"
+```
+
+Stopping preserves the session gallery. Draft and session artifacts are
+discovery evidence, not React source, confirmed snapshots, or publishable
+output.

--- a/skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py
+++ b/skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py
@@ -14,7 +14,7 @@ VALIDATOR = ROOT / "scripts" / "validate_site_design_spec.py"
 
 def valid_spec() -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "spec_id": "site-spec-1",
         "workflow_mode": "full",
         "content_revision": 1,
@@ -40,6 +40,17 @@ def valid_spec() -> dict:
         "representative_interaction": (
             "project selection updates one detail panel"
         ),
+        "visual_preview": {
+            "mode": "local-gallery",
+            "artifact": (
+                ".resume-site-work/style-preview/sessions/style-1/gallery.html"
+            ),
+            "candidate_ids": ["editorial", "cinematic"],
+            "recommended_candidate_id": "editorial",
+            "selected_candidate_id": "editorial",
+            "approval_channel": "conversation",
+            "explicitly_approved": True,
+        },
         "approval": {"status": "user_approved", "source": "explicit_user"},
     }
 
@@ -78,6 +89,30 @@ class SiteDesignSpecValidatorTests(unittest.TestCase):
         payload = valid_spec()
         payload["approval"]["source"] = "inferred"
         self.assertEqual(self.run_validator(payload).returncode, 1)
+
+    def test_rejects_missing_visual_preview(self) -> None:
+        payload = valid_spec()
+        payload.pop("visual_preview")
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("full mode requires visual_preview", result.stdout)
+
+    def test_rejects_browser_approval_channel(self) -> None:
+        payload = valid_spec()
+        payload["visual_preview"]["approval_channel"] = "browser"
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "visual_preview approval_channel must be conversation",
+            result.stdout,
+        )
+
+    def test_rejects_version_one(self) -> None:
+        payload = valid_spec()
+        payload["schema_version"] = 1
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("schema_version must be 2", result.stdout)
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py
@@ -44,6 +44,13 @@ CONTRACTS = (
     "site-design-spec-schema.json",
     "site-planning-contract.md",
     "site-implementation-plan-schema.json",
+    "visual-style-preview-contract.md",
+)
+VISUAL_COMPANION_FILES = (
+    "assets/visual-companion/gallery-shell.html",
+    "scripts/visual_companion/server.cjs",
+    "scripts/visual_companion/launch.cjs",
+    "scripts/visual_companion/stop.cjs",
 )
 
 
@@ -126,6 +133,11 @@ def write_complete_skeleton(root: Path) -> None:
         SKILL_ROOT / "vendor" / "ui-ux-pro-max",
         root / "vendor" / "ui-ux-pro-max",
     )
+    for relative in VISUAL_COMPANION_FILES:
+        source = SKILL_ROOT / relative
+        destination = root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
 
 
 
@@ -194,6 +206,19 @@ class ValidateSkillResourcesTests(unittest.TestCase):
             self.assertFalse(report.ok)
             self.assertIn(
                 "missing_contract: site-planning-contract",
+                report.errors,
+            )
+
+    def test_discovery_rejects_missing_visual_companion_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_complete_skeleton(root)
+            missing = "scripts/visual_companion/launch.cjs"
+            (root / missing).unlink()
+            report = validate_resources(root, "runtime", "discovery")
+            self.assertFalse(report.ok)
+            self.assertIn(
+                f"missing_visual_companion: {missing}",
                 report.errors,
             )
 

--- a/skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -24,6 +24,78 @@ REQUIRED = {
     "approval",
 }
 PLACEHOLDERS = {"todo", "tbd", "implement later", "fill in details"}
+
+
+def _validate_visual_preview(
+    preview: Any,
+    alternative_ids: list[str],
+) -> list[str]:
+    if not isinstance(preview, dict):
+        return ["full mode requires visual_preview"]
+
+    required = {
+        "mode",
+        "artifact",
+        "candidate_ids",
+        "recommended_candidate_id",
+        "selected_candidate_id",
+        "approval_channel",
+        "explicitly_approved",
+    }
+    errors = [
+        f"visual_preview missing field: {name}"
+        for name in sorted(required - set(preview))
+    ]
+    if errors:
+        return errors
+
+    candidate_ids = preview["candidate_ids"]
+    if (
+        not isinstance(candidate_ids, list)
+        or not 2 <= len(candidate_ids) <= 3
+        or not all(
+            isinstance(item, str) and item.strip()
+            for item in candidate_ids
+        )
+        or len(candidate_ids) != len(set(candidate_ids))
+    ):
+        errors.append(
+            "visual_preview candidate_ids must contain "
+            "two or three unique IDs"
+        )
+        candidate_ids = []
+
+    if set(candidate_ids) != set(alternative_ids):
+        errors.append("visual_preview candidate_ids must match alternatives")
+    if preview["mode"] != "local-gallery":
+        errors.append("visual_preview mode must be local-gallery")
+
+    artifact = str(preview["artifact"]).replace("\\", "/")
+    artifact_path = PurePosixPath(artifact)
+    expected_prefix = (
+        ".resume-site-work",
+        "style-preview",
+        "sessions",
+    )
+    if (
+        artifact_path.is_absolute()
+        or ".." in artifact_path.parts
+        or artifact_path.parts[:3] != expected_prefix
+        or len(artifact_path.parts) != 5
+        or artifact_path.parts[-1] != "gallery.html"
+    ):
+        errors.append("visual_preview artifact must be a session gallery")
+
+    for key in ("recommended_candidate_id", "selected_candidate_id"):
+        if preview[key] not in candidate_ids:
+            errors.append(f"visual_preview {key} must reference a candidate")
+    if preview["approval_channel"] != "conversation":
+        errors.append(
+            "visual_preview approval_channel must be conversation"
+        )
+    if preview["explicitly_approved"] is not True:
+        errors.append("visual_preview must be explicitly approved")
+    return errors
 
 
 def _strings(value: Any, *, non_empty: bool = False) -> bool:
@@ -53,8 +125,8 @@ def validate(payload: Any) -> list[str]:
     ]
     if errors:
         return errors
-    if payload["schema_version"] != 1:
-        errors.append("schema_version must be 1")
+    if payload["schema_version"] != 2:
+        errors.append("schema_version must be 2")
     if payload["workflow_mode"] not in {"full", "fast-change"}:
         errors.append("workflow_mode must be full or fast-change")
     if not isinstance(payload["content_revision"], int) or payload[
@@ -108,6 +180,10 @@ def validate(payload: Any) -> list[str]:
         errors.append("layout families must be materially different")
     if payload["selected_alternative_id"] not in ids:
         errors.append("selected_alternative_id must reference an alternative")
+    if payload["workflow_mode"] == "full":
+        errors.extend(
+            _validate_visual_preview(payload.get("visual_preview"), ids)
+        )
 
     approval = payload["approval"]
     if not isinstance(approval, dict):

--- a/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
@@ -39,12 +39,24 @@ CONTRACT_SPECS = {
     "site-implementation-plan-schema": (
         "references/site-implementation-plan-schema.json"
     ),
+    "visual-style-preview-contract": (
+        "references/visual-style-preview-contract.md"
+    ),
 }
+
+VISUAL_COMPANION_FILES = (
+    "assets/visual-companion/gallery-shell.html",
+    "scripts/visual_companion/server.cjs",
+    "scripts/visual_companion/launch.cjs",
+    "scripts/visual_companion/stop.cjs",
+)
 
 STAGE_RESOURCES = {
     "discovery": (
         "site-brainstorming-contract",
         "site-design-spec-schema",
+        "visual-style-preview-contract",
+        "visual-companion",
     ),
     "planning": (
         "site-planning-contract",
@@ -225,7 +237,12 @@ def validate_resources(skill_root: Path, mode: str, stage: str | None, workspace
     resources = (
         tuple(PROMPT_SPECS)
         + tuple(CONTRACT_SPECS)
-        + ("reference-library", "motion-catalog", "design-catalog")
+        + (
+            "reference-library",
+            "motion-catalog",
+            "design-catalog",
+            "visual-companion",
+        )
         if mode == "skeleton"
         else STAGE_RESOURCES[stage]
     )
@@ -277,6 +294,13 @@ def validate_resources(skill_root: Path, mode: str, stage: str | None, workspace
                 else:
                     resource_errors.append(f"invalid_motion_catalog: {error}")
             resource_ready = catalog_report.ready
+        elif resource_id == "visual-companion":
+            resource_errors = [
+                f"missing_visual_companion: {relative}"
+                for relative in VISUAL_COMPANION_FILES
+                if not (skill_root / relative).is_file()
+            ]
+            resource_ready = not resource_errors
         else:
             resource_errors, resource_ready = _validate_prompt(
                 skill_root, resource_id, require_ready

--- a/skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs
+++ b/skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs
@@ -1,0 +1,247 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const {spawn} = require("child_process");
+
+function parseArgs(argv) {
+  const values = {open: false, foreground: false};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (name === "--open" || name === "--foreground") {
+      values[name.slice(2)] = true;
+      continue;
+    }
+    if (!name.startsWith("--")) {
+      throw new Error(`unexpected argument: ${name}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`missing value for ${name}`);
+    }
+    values[name.slice(2)] = value;
+    index += 1;
+  }
+  return values;
+}
+
+function outputError(category, message) {
+  process.stderr.write(`${JSON.stringify({
+    type: "launch-error",
+    category,
+    message,
+  })}\n`);
+  process.exitCode = 1;
+}
+
+function atomicJson(file, payload) {
+  const temporary = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  fs.renameSync(temporary, file);
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // Windows ACLs remain the platform authority.
+  }
+}
+
+function waitForStartup(child, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const timeout = setTimeout(() => {
+      reject(new Error("server startup timed out"));
+    }, timeoutMs);
+    function finish(error, value) {
+      clearTimeout(timeout);
+      child.stdout.removeAllListeners();
+      child.removeListener("exit", onExit);
+      if (error) reject(error);
+      else resolve(value);
+    }
+    function onExit(code) {
+      finish(new Error(`server exited before startup with code ${code}`));
+    }
+    child.once("exit", onExit);
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk;
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = buffer.slice(0, newline);
+      try {
+        finish(null, JSON.parse(line));
+      } catch (error) {
+        finish(new Error(`invalid server startup JSON: ${error.message}`));
+      }
+    });
+  });
+}
+
+function browserCommand(url) {
+  if (process.env.VISUAL_COMPANION_OPEN_COMMAND) {
+    return {
+      command: process.env.VISUAL_COMPANION_OPEN_COMMAND,
+      args: [url],
+    };
+  }
+  if (process.platform === "win32") {
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Start-Process -FilePath $args[0]",
+        url,
+      ],
+    };
+  }
+  if (process.platform === "darwin") {
+    return {command: "open", args: [url]};
+  }
+  return {command: "xdg-open", args: [url]};
+}
+
+function openBrowser(url) {
+  return new Promise((resolve) => {
+    const launcher = browserCommand(url);
+    let settled = false;
+    const child = spawn(launcher.command, launcher.args, {
+      detached: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    function done(value) {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    }
+    child.once("error", () => done("OPEN_FAILED"));
+    child.once("spawn", () => {
+      child.unref();
+      done(null);
+    });
+  });
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    outputError("INVALID_ARGUMENT", error.message);
+    return;
+  }
+  if (!args["workspace-root"] || !args.gallery) {
+    outputError(
+      "INVALID_ARGUMENT",
+      "workspace-root and gallery are required",
+    );
+    return;
+  }
+
+  const workspaceRoot = path.resolve(args["workspace-root"]);
+  const sourceGallery = path.resolve(args.gallery);
+  let sourceStat;
+  try {
+    sourceStat = fs.lstatSync(sourceGallery);
+  } catch (error) {
+    outputError("INVALID_PREVIEW_PATH", error.message);
+    return;
+  }
+  if (
+    sourceStat.isSymbolicLink()
+    || !sourceStat.isFile()
+    || path.extname(sourceGallery).toLowerCase() !== ".html"
+  ) {
+    outputError(
+      "INVALID_PREVIEW_PATH",
+      "gallery must be a regular HTML file",
+    );
+    return;
+  }
+
+  const sessionsRoot = path.join(
+    workspaceRoot,
+    ".resume-site-work",
+    "style-preview",
+    "sessions",
+  );
+  fs.mkdirSync(sessionsRoot, {recursive: true});
+  const sessionDir = fs.mkdtempSync(path.join(sessionsRoot, "style-"));
+  const stateDir = path.join(sessionDir, "state");
+  fs.mkdirSync(stateDir);
+  const gallery = path.join(sessionDir, "gallery.html");
+  fs.copyFileSync(sourceGallery, gallery);
+  const sourceAssets = path.join(path.dirname(sourceGallery), "assets");
+  if (fs.existsSync(sourceAssets) && fs.lstatSync(sourceAssets).isDirectory()) {
+    fs.cpSync(sourceAssets, path.join(sessionDir, "assets"), {
+      recursive: true,
+      errorOnExist: true,
+    });
+  }
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const serverScript = path.join(__dirname, "server.cjs");
+  const logPath = path.join(stateDir, "server.log");
+  const logFd = fs.openSync(logPath, "a", 0o600);
+  const child = spawn(
+    process.execPath,
+    [
+      serverScript,
+      "--session-dir",
+      sessionDir,
+      "--gallery",
+      gallery,
+      "--host",
+      args.host || "127.0.0.1",
+      "--port",
+      args.port || "0",
+      "--token",
+      token,
+    ],
+    {
+      cwd: sessionDir,
+      detached: !args.foreground,
+      stdio: ["ignore", "pipe", logFd],
+      windowsHide: true,
+    },
+  );
+  fs.closeSync(logFd);
+
+  let startup;
+  try {
+    startup = await waitForStartup(child, 5000);
+  } catch (error) {
+    if (child.exitCode === null) child.kill();
+    outputError("SERVER_REAPED", error.message);
+    return;
+  }
+
+  let openWarning = null;
+  if (args.open) openWarning = await openBrowser(startup.url);
+  const serverInfoPath = path.join(stateDir, "server-info.json");
+  const info = {
+    ...startup,
+    server_info: serverInfoPath,
+    open_warning: openWarning,
+  };
+  atomicJson(serverInfoPath, info);
+  process.stdout.write(`${JSON.stringify(info)}\n`);
+
+  if (args.foreground) {
+    child.stdout.resume();
+    await new Promise((resolve) => child.once("exit", resolve));
+  } else {
+    child.stdout.destroy();
+    child.unref();
+  }
+}
+
+main().catch((error) => {
+  outputError("LAUNCH_FAILED", error.message);
+});

--- a/skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
+++ b/skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
@@ -1,0 +1,264 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+
+const MIME = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
+  [".js", "application/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".webp", "image/webp"],
+  [".gif", "image/gif"],
+]);
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (!name.startsWith("--")) {
+      throw new Error(`unexpected argument: ${name}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`missing value for ${name}`);
+    }
+    values[name.slice(2)] = value;
+    index += 1;
+  }
+  return values;
+}
+
+function safeEqual(left, right) {
+  const first = Buffer.from(String(left));
+  const second = Buffer.from(String(right));
+  return (
+    first.length === second.length
+    && crypto.timingSafeEqual(first, second)
+  );
+}
+
+function isInside(root, target) {
+  const relative = path.relative(root, target);
+  return (
+    relative === ""
+    || (
+      relative !== ".."
+      && !relative.startsWith(`..${path.sep}`)
+      && !path.isAbsolute(relative)
+    )
+  );
+}
+
+function cookieValue(header, name) {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const [key, ...rest] = part.trim().split("=");
+    if (key === name) return rest.join("=");
+  }
+  return null;
+}
+
+function securityHeaders(extra = {}) {
+  return {
+    "Cache-Control": "no-store",
+    "Content-Security-Policy": [
+      "default-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data:",
+      "font-src 'self' data:",
+      "script-src 'none'",
+      "object-src 'none'",
+      "base-uri 'none'",
+      "frame-ancestors 'none'",
+    ].join("; "),
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    ...extra,
+  };
+}
+
+function fail(category, message) {
+  process.stderr.write(`${JSON.stringify({
+    type: "server-error",
+    category,
+    message,
+  })}\n`);
+  process.exitCode = 1;
+}
+
+let args;
+try {
+  args = parseArgs(process.argv.slice(2));
+} catch (error) {
+  fail("INVALID_ARGUMENT", error.message);
+  return;
+}
+
+const host = args.host || "127.0.0.1";
+const port = Number(args.port || "0");
+const token = args.token || "";
+if (!Number.isInteger(port) || port < 0 || port > 65535) {
+  fail("INVALID_ARGUMENT", "port must be an integer from 0 to 65535");
+  return;
+}
+if (token.length < 16) {
+  fail("INVALID_ARGUMENT", "token must contain at least 16 characters");
+  return;
+}
+if (!args["session-dir"] || !args.gallery) {
+  fail("INVALID_ARGUMENT", "session-dir and gallery are required");
+  return;
+}
+
+let sessionRoot;
+let galleryPath;
+try {
+  sessionRoot = fs.realpathSync(path.resolve(args["session-dir"]));
+  galleryPath = fs.realpathSync(path.resolve(args.gallery));
+  const galleryStat = fs.lstatSync(galleryPath);
+  if (
+    !isInside(sessionRoot, galleryPath)
+    || galleryStat.isSymbolicLink()
+    || !galleryStat.isFile()
+    || path.extname(galleryPath).toLowerCase() !== ".html"
+  ) {
+    throw new Error("gallery must be a regular HTML file inside session-dir");
+  }
+} catch (error) {
+  fail("INVALID_PREVIEW_PATH", error.message);
+  return;
+}
+
+const cookieName = `visual-preview-key-${crypto
+  .createHash("sha256")
+  .update(token)
+  .digest("hex")
+  .slice(0, 12)}`;
+
+function authorized(requestUrl, request) {
+  const queryKey = requestUrl.searchParams.get("key");
+  const cookieKey = cookieValue(request.headers.cookie, cookieName);
+  return safeEqual(queryKey || cookieKey || "", token);
+}
+
+function regularAllowedFile(target) {
+  try {
+    const realTarget = fs.realpathSync(target);
+    const stat = fs.lstatSync(target);
+    return (
+      isInside(sessionRoot, realTarget)
+      && stat.isFile()
+      && !stat.isSymbolicLink()
+      && MIME.has(path.extname(realTarget).toLowerCase())
+    )
+      ? realTarget
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function responseFile(request, response, target) {
+  const data = fs.readFileSync(target);
+  const contentType = MIME.get(path.extname(target).toLowerCase());
+  response.writeHead(200, securityHeaders({
+    "Content-Length": String(data.length),
+    "Content-Type": contentType,
+  }));
+  if (request.method === "HEAD") response.end();
+  else response.end(data);
+}
+
+const server = http.createServer((request, response) => {
+  if (!["GET", "HEAD"].includes(request.method)) {
+    response.writeHead(405, securityHeaders({
+      Allow: "GET, HEAD",
+      "Content-Type": "text/plain; charset=utf-8",
+    }));
+    response.end("Method not allowed");
+    return;
+  }
+
+  const base = `http://${request.headers.host || `${host}:${port}`}`;
+  let requestUrl;
+  try {
+    requestUrl = new URL(request.url, base);
+  } catch {
+    response.writeHead(400, securityHeaders());
+    response.end("Bad request");
+    return;
+  }
+  if (!authorized(requestUrl, request)) {
+    response.writeHead(403, securityHeaders({
+      "Content-Type": "text/plain; charset=utf-8",
+    }));
+    response.end("Forbidden");
+    return;
+  }
+
+  if (requestUrl.searchParams.has("key")) {
+    response.setHeader(
+      "Set-Cookie",
+      `${cookieName}=${token}; HttpOnly; SameSite=Strict; Path=/`,
+    );
+  }
+
+  if (requestUrl.pathname === "/") {
+    responseFile(request, response, galleryPath);
+    return;
+  }
+  if (requestUrl.pathname.startsWith("/files/")) {
+    let relative;
+    try {
+      relative = decodeURIComponent(requestUrl.pathname.slice(7));
+    } catch {
+      relative = "";
+    }
+    const target = regularAllowedFile(path.resolve(sessionRoot, relative));
+    if (target) {
+      responseFile(request, response, target);
+      return;
+    }
+  }
+  response.writeHead(404, securityHeaders({
+    "Content-Type": "text/plain; charset=utf-8",
+  }));
+  response.end("Not found");
+});
+
+server.on("error", (error) => {
+  fail(
+    error.code === "EADDRINUSE" ? "PORT_BIND_FAILED" : "SERVER_FAILED",
+    error.message,
+  );
+});
+
+function stop() {
+  server.close(() => process.exit(0));
+}
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);
+
+server.listen(port, host, () => {
+  const address = server.address();
+  const activePort = address.port;
+  const url = `http://${host}:${activePort}/?key=${encodeURIComponent(token)}`;
+  process.stdout.write(`${JSON.stringify({
+    type: "server-started",
+    pid: process.pid,
+    port: activePort,
+    host,
+    url,
+    session_dir: sessionRoot,
+    gallery: galleryPath,
+  })}\n`);
+});

--- a/skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
+++ b/skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
@@ -216,6 +216,20 @@ const server = http.createServer((request, response) => {
     responseFile(request, response, galleryPath);
     return;
   }
+  if (requestUrl.pathname === "/health") {
+    const data = Buffer.from(JSON.stringify({
+      type: "visual-companion-health",
+      pid: process.pid,
+      session_dir: sessionRoot,
+    }));
+    response.writeHead(200, securityHeaders({
+      "Content-Length": String(data.length),
+      "Content-Type": "application/json; charset=utf-8",
+    }));
+    if (request.method === "HEAD") response.end();
+    else response.end(data);
+    return;
+  }
   if (requestUrl.pathname.startsWith("/files/")) {
     let relative;
     try {

--- a/skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs
+++ b/skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs
@@ -1,0 +1,177 @@
+"use strict";
+
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (
+      !name.startsWith("--")
+      || value === undefined
+      || value.startsWith("--")
+    ) {
+      throw new Error(`invalid argument near ${name}`);
+    }
+    values[name.slice(2)] = value;
+    index += 1;
+  }
+  return values;
+}
+
+function isInside(root, target) {
+  const relative = path.relative(root, target);
+  return (
+    relative === ""
+    || (
+      relative !== ".."
+      && !relative.startsWith(`..${path.sep}`)
+      && !path.isAbsolute(relative)
+    )
+  );
+}
+
+function outputError(category, message) {
+  process.stderr.write(`${JSON.stringify({
+    type: "stop-error",
+    category,
+    message,
+  })}\n`);
+  process.exitCode = 1;
+}
+
+function healthUrl(url) {
+  const target = new URL(url);
+  target.pathname = "/health";
+  return target;
+}
+
+function readHealth(url, timeoutMs = 1500) {
+  return new Promise((resolve, reject) => {
+    const request = http.get(url, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`health returned ${response.statusCode}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(body));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error("health timed out"));
+    });
+    request.once("error", reject);
+  });
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    outputError("INVALID_ARGUMENT", error.message);
+    return;
+  }
+  if (!args["workspace-root"] || !args["server-info"]) {
+    outputError(
+      "INVALID_ARGUMENT",
+      "workspace-root and server-info are required",
+    );
+    return;
+  }
+
+  const workspaceRoot = path.resolve(args["workspace-root"]);
+  const sessionsRoot = path.resolve(
+    workspaceRoot,
+    ".resume-site-work",
+    "style-preview",
+    "sessions",
+  );
+  const serverInfoPath = path.resolve(args["server-info"]);
+  if (
+    !isInside(sessionsRoot, serverInfoPath)
+    || path.basename(serverInfoPath) !== "server-info.json"
+    || path.basename(path.dirname(serverInfoPath)) !== "state"
+  ) {
+    outputError(
+      "INVALID_SESSION_PATH",
+      "server-info must belong to the workspace sessions directory",
+    );
+    return;
+  }
+
+  let info;
+  try {
+    info = JSON.parse(fs.readFileSync(serverInfoPath, "utf8"));
+  } catch (error) {
+    outputError("INVALID_SERVER_INFO", error.message);
+    return;
+  }
+  const sessionDir = path.resolve(info.session_dir || "");
+  const expectedSession = path.dirname(path.dirname(serverInfoPath));
+  if (
+    sessionDir !== expectedSession
+    || !isInside(sessionsRoot, sessionDir)
+    || !Number.isInteger(info.pid)
+    || typeof info.url !== "string"
+  ) {
+    outputError("INVALID_SERVER_INFO", "server identity is inconsistent");
+    return;
+  }
+
+  let health;
+  try {
+    health = await readHealth(healthUrl(info.url));
+  } catch (error) {
+    outputError("SERVER_NOT_VERIFIED", error.message);
+    return;
+  }
+  if (
+    health.pid !== info.pid
+    || path.resolve(health.session_dir || "") !== sessionDir
+  ) {
+    outputError("SERVER_NOT_VERIFIED", "health identity does not match");
+    return;
+  }
+
+  try {
+    process.kill(info.pid, "SIGTERM");
+  } catch (error) {
+    outputError("STOP_FAILED", error.message);
+    return;
+  }
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await delay(100);
+    try {
+      await readHealth(healthUrl(info.url), 200);
+    } catch {
+      process.stdout.write(`${JSON.stringify({
+        type: "server-stopped",
+        pid: info.pid,
+        session_dir: sessionDir,
+      })}\n`);
+      return;
+    }
+  }
+  outputError("STOP_FAILED", "server did not stop within three seconds");
+}
+
+main().catch((error) => {
+  outputError("STOP_FAILED", error.message);
+});

--- a/tests/fixtures/site-design-spec-valid.json
+++ b/tests/fixtures/site-design-spec-valid.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "spec_id": "site-spec-1",
   "workflow_mode": "full",
   "content_revision": 1,
@@ -23,6 +23,15 @@
   "composition_commitment": "asymmetric editorial stage",
   "type_color_character": "high-contrast serif and restrained yellow",
   "representative_interaction": "project selection updates one detail panel",
+  "visual_preview": {
+    "mode": "local-gallery",
+    "artifact": ".resume-site-work/style-preview/sessions/style-1/gallery.html",
+    "candidate_ids": ["editorial", "cinematic"],
+    "recommended_candidate_id": "editorial",
+    "selected_candidate_id": "editorial",
+    "approval_channel": "conversation",
+    "explicitly_approved": true
+  },
   "approval": {
     "status": "user_approved",
     "source": "explicit_user"

--- a/tests/test_visual_companion.py
+++ b/tests/test_visual_companion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -20,6 +21,8 @@ VISUAL_ROOT = (
     / "visual_companion"
 )
 SERVER = VISUAL_ROOT / "server.cjs"
+LAUNCH = VISUAL_ROOT / "launch.cjs"
+STOP = VISUAL_ROOT / "stop.cjs"
 NODE = shutil.which("node")
 
 
@@ -164,6 +167,167 @@ class VisualCompanionServerTests(unittest.TestCase):
     def test_server_defaults_to_loopback(self) -> None:
         self.assertEqual(self.info["host"], "127.0.0.1")
         self.assertTrue(self.info["url"].startswith("http://127.0.0.1:"))
+
+    def test_health_identifies_the_exact_server_instance(self) -> None:
+        with self.open("/health") as response:
+            payload = json.loads(response.read())
+        self.assertEqual(payload["pid"], self.info["pid"])
+        self.assertEqual(
+            Path(payload["session_dir"]).resolve(),
+            self.session,
+        )
+
+
+@unittest.skipUnless(NODE, "Node.js is required for visual companion tests")
+class VisualCompanionLifecycleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.workspace = (Path(self.temp.name) / "workspace").resolve()
+        self.workspace.mkdir()
+        self.source = Path(self.temp.name) / "source"
+        self.source.mkdir()
+        self.gallery = self.source / "gallery.html"
+        self.gallery.write_text(
+            "<!doctype html><h1>Portable directions</h1>",
+            encoding="utf-8",
+        )
+        assets = self.source / "assets"
+        assets.mkdir()
+        (assets / "mark.svg").write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+            encoding="utf-8",
+        )
+        self.sessions: list[dict] = []
+
+    def tearDown(self) -> None:
+        for info in self.sessions:
+            subprocess.run(
+                [
+                    NODE,
+                    str(STOP),
+                    "--workspace-root",
+                    str(self.workspace),
+                    "--server-info",
+                    info["server_info"],
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        self.temp.cleanup()
+
+    def launch(
+        self,
+        *,
+        open_browser: bool = False,
+        extra_env: dict[str, str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], dict]:
+        command = [
+            NODE,
+            str(LAUNCH),
+            "--workspace-root",
+            str(self.workspace),
+            "--gallery",
+            str(self.gallery),
+        ]
+        if open_browser:
+            command.append("--open")
+        environment = os.environ.copy()
+        environment.update(extra_env or {})
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+            env=environment,
+        )
+        info = json.loads(result.stdout.splitlines()[0]) if result.stdout else {}
+        if info.get("server_info"):
+            self.sessions.append(info)
+        return result, info
+
+    def test_launch_creates_contained_session_and_server_info(self) -> None:
+        result, info = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        session = Path(info["session_dir"]).resolve()
+        expected = (
+            self.workspace
+            / ".resume-site-work"
+            / "style-preview"
+            / "sessions"
+        ).resolve()
+        self.assertTrue(session.is_relative_to(expected))
+        self.assertEqual(
+            Path(info["server_info"]).resolve(),
+            session / "state" / "server-info.json",
+        )
+        self.assertTrue(Path(info["server_info"]).is_file())
+        self.assertTrue((session / "gallery.html").is_file())
+        self.assertTrue((session / "assets" / "mark.svg").is_file())
+        with urllib.request.urlopen(info["url"], timeout=3) as response:
+            self.assertIn(b"Portable directions", response.read())
+
+    def test_open_failure_does_not_stop_server(self) -> None:
+        result, info = self.launch(
+            open_browser=True,
+            extra_env={
+                "VISUAL_COMPANION_OPEN_COMMAND":
+                    "__missing_visual_open_command__"
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(info["open_warning"], "OPEN_FAILED")
+        with urllib.request.urlopen(info["url"], timeout=3) as response:
+            self.assertEqual(response.status, 200)
+
+    def test_stop_terminates_verified_session_and_keeps_gallery(self) -> None:
+        _, info = self.launch()
+        session = Path(info["session_dir"])
+        result = subprocess.run(
+            [
+                NODE,
+                str(STOP),
+                "--workspace-root",
+                str(self.workspace),
+                "--server-info",
+                info["server_info"],
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        self.sessions.remove(info)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["type"], "server-stopped")
+        self.assertTrue((session / "gallery.html").is_file())
+        with self.assertRaises((urllib.error.URLError, TimeoutError)):
+            urllib.request.urlopen(info["url"], timeout=1)
+
+    def test_stop_rejects_server_info_outside_workspace(self) -> None:
+        outside = Path(self.temp.name) / "outside.json"
+        outside.write_text(
+            json.dumps({"pid": os.getpid()}),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                NODE,
+                str(STOP),
+                "--workspace-root",
+                str(self.workspace),
+                "--server-info",
+                str(outside),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("INVALID_SESSION_PATH", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_visual_companion.py
+++ b/tests/test_visual_companion.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VISUAL_ROOT = (
+    ROOT
+    / "skills"
+    / "build-resume-portfolio-site"
+    / "scripts"
+    / "visual_companion"
+)
+SERVER = VISUAL_ROOT / "server.cjs"
+NODE = shutil.which("node")
+
+
+@unittest.skipUnless(NODE, "Node.js is required for visual companion tests")
+class VisualCompanionServerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.session = Path(self.temp.name).resolve()
+        self.gallery = self.session / "gallery.html"
+        self.gallery.write_text(
+            "<!doctype html><html><body><h1>Directions</h1></body></html>",
+            encoding="utf-8",
+        )
+        assets = self.session / "assets"
+        assets.mkdir()
+        (assets / "sample.svg").write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+            encoding="utf-8",
+        )
+        self.token = "test-token-1234567890"
+        self.process = subprocess.Popen(
+            [
+                NODE,
+                str(SERVER),
+                "--session-dir",
+                str(self.session),
+                "--gallery",
+                str(self.gallery),
+                "--port",
+                "0",
+                "--token",
+                self.token,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert self.process.stdout is not None
+        startup_line = self.process.stdout.readline()
+        if not startup_line:
+            stderr = ""
+            if self.process.stderr is not None:
+                stderr = self.process.stderr.read()
+            self.fail(f"server did not start: {stderr}")
+        self.info = json.loads(startup_line)
+
+    def tearDown(self) -> None:
+        if hasattr(self, "process") and self.process.poll() is None:
+            self.process.terminate()
+            self.process.wait(timeout=5)
+        if hasattr(self, "process"):
+            if self.process.stdout is not None:
+                self.process.stdout.close()
+            if self.process.stderr is not None:
+                self.process.stderr.close()
+        self.temp.cleanup()
+
+    def open(
+        self,
+        path: str = "/",
+        *,
+        key: str | None = None,
+        method: str = "GET",
+        data: bytes | None = None,
+    ):
+        query_key = self.token if key is None else key
+        url = (
+            f"http://127.0.0.1:{self.info['port']}{path}"
+            f"?key={urllib.parse.quote(query_key)}"
+        )
+        request = urllib.request.Request(url, method=method, data=data)
+        return urllib.request.urlopen(request, timeout=3)
+
+    def test_authenticated_get_serves_gallery_with_security_headers(
+        self,
+    ) -> None:
+        with self.open() as response:
+            self.assertEqual(response.status, 200)
+            self.assertIn(b"Directions", response.read())
+            self.assertEqual(response.headers["Cache-Control"], "no-store")
+            self.assertEqual(
+                response.headers["X-Content-Type-Options"],
+                "nosniff",
+            )
+            self.assertEqual(response.headers["X-Frame-Options"], "DENY")
+            self.assertEqual(
+                response.headers["Referrer-Policy"],
+                "no-referrer",
+            )
+            self.assertEqual(
+                response.headers["Cross-Origin-Resource-Policy"],
+                "same-origin",
+            )
+            self.assertIn(
+                "default-src 'self'",
+                response.headers["Content-Security-Policy"],
+            )
+
+    def test_missing_or_wrong_key_is_forbidden(self) -> None:
+        base = f"http://127.0.0.1:{self.info['port']}/"
+        for url in (base, f"{base}?key=wrong"):
+            with self.subTest(url=url):
+                with self.assertRaises(urllib.error.HTTPError) as caught:
+                    urllib.request.urlopen(url, timeout=3)
+                self.assertEqual(caught.exception.code, 403)
+
+    def test_head_returns_headers_without_body(self) -> None:
+        with self.open(method="HEAD") as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.read(), b"")
+            self.assertIn("text/html", response.headers["Content-Type"])
+
+    def test_write_methods_are_rejected(self) -> None:
+        for method in ("POST", "PUT", "PATCH", "DELETE"):
+            with self.subTest(method=method):
+                with self.assertRaises(urllib.error.HTTPError) as caught:
+                    self.open(method=method, data=b"x")
+                self.assertEqual(caught.exception.code, 405)
+                self.assertEqual(caught.exception.headers["Allow"], "GET, HEAD")
+
+    def test_local_asset_uses_expected_mime_type(self) -> None:
+        with self.open("/files/assets/sample.svg") as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.headers["Content-Type"], "image/svg+xml")
+
+    def test_traversal_and_unsupported_files_are_not_served(self) -> None:
+        (self.session.parent / "secret.txt").write_text(
+            "secret",
+            encoding="utf-8",
+        )
+        (self.session / "payload.exe").write_bytes(b"MZ")
+        for path in (
+            "/files/%2e%2e/secret.txt",
+            "/files/payload.exe",
+            "/files/missing.svg",
+        ):
+            with self.subTest(path=path):
+                with self.assertRaises(urllib.error.HTTPError) as caught:
+                    self.open(path)
+                self.assertEqual(caught.exception.code, 404)
+
+    def test_server_defaults_to_loopback(self) -> None:
+        self.assertEqual(self.info["host"], "127.0.0.1")
+        self.assertTrue(self.info["url"].startswith("http://127.0.0.1:"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visual_companion.py
+++ b/tests/test_visual_companion.py
@@ -23,6 +23,14 @@ VISUAL_ROOT = (
 SERVER = VISUAL_ROOT / "server.cjs"
 LAUNCH = VISUAL_ROOT / "launch.cjs"
 STOP = VISUAL_ROOT / "stop.cjs"
+GALLERY_SHELL = (
+    ROOT
+    / "skills"
+    / "build-resume-portfolio-site"
+    / "assets"
+    / "visual-companion"
+    / "gallery-shell.html"
+)
 NODE = shutil.which("node")
 
 
@@ -328,6 +336,29 @@ class VisualCompanionLifecycleTests(unittest.TestCase):
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("INVALID_SESSION_PATH", result.stderr)
+
+
+class VisualCompanionPackageTests(unittest.TestCase):
+    def test_gallery_shell_is_display_only(self) -> None:
+        text = GALLERY_SHELL.read_text(encoding="utf-8").lower()
+        self.assertNotIn("<form", text)
+        self.assertNotIn("data-choice", text)
+        self.assertNotIn("<button", text)
+        self.assertIn("approve in the conversation", text)
+        self.assertIn("<!-- visual-directions -->", text)
+
+    def test_visual_companion_resources_are_packaged(self) -> None:
+        skill_root = ROOT / "skills" / "build-resume-portfolio-site"
+        required = (
+            "assets/visual-companion/gallery-shell.html",
+            "references/visual-style-preview-contract.md",
+            "scripts/visual_companion/server.cjs",
+            "scripts/visual_companion/launch.cjs",
+            "scripts/visual_companion/stop.cjs",
+        )
+        for relative in required:
+            with self.subTest(relative=relative):
+                self.assertTrue((skill_root / relative).is_file(), relative)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_behavior_contract.py
+++ b/tests/test_workflow_behavior_contract.py
@@ -104,6 +104,41 @@ class WorkflowBehaviorContractTests(unittest.TestCase):
         )
         self.assertNotEqual(result.returncode, 0)
 
+    def test_full_site_requires_visual_preview(self) -> None:
+        result = self.run_validator(
+            "build-resume-portfolio-site",
+            "validate_site_design_spec.py",
+            "site-design-spec-valid.json",
+            lambda payload: payload.pop("visual_preview"),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("full mode requires visual_preview", result.stdout)
+
+    def test_browser_activity_cannot_approve_site_design(self) -> None:
+        result = self.run_validator(
+            "build-resume-portfolio-site",
+            "validate_site_design_spec.py",
+            "site-design-spec-valid.json",
+            lambda payload: payload["visual_preview"].update(
+                {"approval_channel": "browser"}
+            ),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "visual_preview approval_channel must be conversation",
+            result.stdout,
+        )
+
+    def test_version_one_site_design_is_rejected(self) -> None:
+        result = self.run_validator(
+            "build-resume-portfolio-site",
+            "validate_site_design_spec.py",
+            "site-design-spec-valid.json",
+            lambda payload: payload.update({"schema_version": 1}),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("schema_version must be 2", result.stdout)
+
     def test_unsupported_claim_cannot_enter_content_plan(self) -> None:
         def remove_evidence(payload: dict) -> None:
             task = payload["tasks"][0]

--- a/tests/test_workflow_behavior_contract.py
+++ b/tests/test_workflow_behavior_contract.py
@@ -48,6 +48,18 @@ class WorkflowBehaviorContractTests(unittest.TestCase):
         ):
             self.assertTrue((ROOT / "skills" / name / "SKILL.md").is_file())
 
+    def test_visual_companion_is_packaged_with_website_skill(self) -> None:
+        root = ROOT / "skills" / "build-resume-portfolio-site"
+        for relative in (
+            "assets/visual-companion/gallery-shell.html",
+            "references/visual-style-preview-contract.md",
+            "scripts/visual_companion/server.cjs",
+            "scripts/visual_companion/launch.cjs",
+            "scripts/visual_companion/stop.cjs",
+        ):
+            with self.subTest(relative=relative):
+                self.assertTrue((root / relative).is_file(), relative)
+
     def test_domain_skills_internalize_discovery_and_planning(self) -> None:
         for name in ("resume-content-intelligence", "build-resume-portfolio-site"):
             text = self.read_skill(name)

--- a/tests/test_workflow_behavior_contract.py
+++ b/tests/test_workflow_behavior_contract.py
@@ -72,6 +72,48 @@ class WorkflowBehaviorContractTests(unittest.TestCase):
         self.assertIn("Do not edit React source before", text)
         self.assertIn("site-design-spec.json", text)
 
+    def test_site_discovery_requires_display_only_visual_gallery(self) -> None:
+        text = self.read_skill("build-resume-portfolio-site").lower()
+        self.assertIn("visual-style-preview-contract.md", text)
+        self.assertIn("approval remains in the conversation", text)
+        self.assertIn("launch.cjs", text)
+        self.assertIn("complete authenticated url", text)
+        self.assertIn("static html fallback", text)
+        self.assertIn("do not edit react source", text)
+
+    def test_browser_activity_never_counts_as_approval(self) -> None:
+        contract = (
+            ROOT
+            / "skills"
+            / "build-resume-portfolio-site"
+            / "references"
+            / "site-brainstorming-contract.md"
+        ).read_text(encoding="utf-8").lower()
+        self.assertIn("browser activity never counts as approval", contract)
+        self.assertIn("two or three", contract)
+        self.assertIn("gallery.html", contract)
+
+    def test_artifact_layout_owns_style_preview_sessions(self) -> None:
+        layout = (
+            ROOT
+            / "skills"
+            / "build-resume-portfolio-site"
+            / "references"
+            / "artifact-layout.md"
+        ).read_text(encoding="utf-8").lower()
+        self.assertIn("style-preview", layout)
+        self.assertIn("discovery evidence", layout)
+        self.assertIn("not react source", layout)
+
+    def test_readme_documents_cross_agent_visual_preview(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()
+        self.assertIn("visual companion", readme)
+        self.assertIn("codex", readme)
+        self.assertIn("claude code", readme)
+        self.assertIn("cursor", readme)
+        self.assertIn("copilot cli", readme)
+        self.assertIn("conversation", readme)
+
     def test_valid_full_workflow_artifacts_pass(self) -> None:
         cases = (
             (


### PR DESCRIPTION
## Summary

- add the portable, display-only visual companion for portfolio style exploration
- keep browser activity read-only and require approval in the Codex conversation
- package local gallery serving and session lifecycle support

## Follow-up

The upfront six-decision workflow, TODO-plan approval gate, and one-pass integrated site generation continue in #2.