### PR TITLE
feat: require upfront portfolio design decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,80 @@
 # Resume Portfolio Workflow
 
-一个包含三个协作 Skill 的 Codex 插件：先识别任务路径，再验证简历内容，最后生成具有明确视觉方向的 React + Vite 个人网站。
+一个将简历材料转化为已核验内容与 React + Vite 个人作品集网站的 Codex
+Skill 组合。
 
-## 包含的 Skills
+## Skills
 
-- `resume-portfolio-workflow`：在内容全流程、网站全流程和已有网站快速修改之间进行路由。
-- `resume-content-intelligence`：提取与核验事实，比较内容策略，生成实施计划，并输出用户批准的内容包。
-- `build-resume-portfolio-site`：比较创意版式方向，在用户批准后生成实施计划，再构建、审查和增强 React + Vite 网站。
+- `resume-portfolio-workflow`：在内容工作、完整建站和已有网站局部修改之间路由。
+- `resume-content-intelligence`：提取、核验并优化简历事实与文案。
+- `build-resume-portfolio-site`：确认完整设计需求和 TODO Plan 后，一次生成完整网站。
 
-## 核心链路
+## 完整建站流程
 
 ```text
-任务路由
-→ 内容盘点与逐问澄清
-→ 2–3 种内容策略
-→ 内容策略批准与实施计划
-→ 最终文案批准
-→ 2–3 种网站视觉方向
-→ 网站设计批准与实施计划
-→ 单 Agent 或经授权的多 Agent 实现
-→ 构建、截图审查、动效与媒体增强
-→ 最终验证和交付
+内容核验
+→ 整体结构
+→ 字体排版
+→ 配色系统
+→ 条件性媒体处理
+→ 主动效
+→ 可多选的兼容副动效
+→ 完整需求确认
+→ 可读 TODO Plan 展示与批准
+→ 可验证实施计划
+→ 一次生成完整 React + Vite 网站
+→ 自动构建、截图审查与有限修复
+→ 接受 / 加强动效 / 提出修改
 ```
 
-新网站、内容变化和结构/视觉方向变化必须经过完整探索与计划流程。只有已有确认版本上的局部修改，且不改变事实、定位、结构、视觉命题或交互架构时，才能进入快速修改路径。
+每个启用的设计类别都会先在对话中给出候选与建议。用户初选后，Skill
+会单独询问是否打开浏览器预览。因此最多可以分别打开六次浏览器；每次
+预览相互独立，不累计，也不会拼接成最终网站。
 
-## 内置能力
+## Visual Companion
 
-- Superpowers 式逐步头脑风暴、方案比较、显式批准和可执行计划。
-- 基于证据的简历内容核验，禁止虚构指标、经历和技能。
-- Taste 风格的创意版式词汇与开放视觉探索。
-- 离线 UI/UX 设计目录、媒体艺术指导和参考图工作流。
-- 内置 Visual Companion：无需 Codex Browser 插件或 npm 安装，在系统浏览器中并排展示 2–3 个视觉方向，最终选择与批准只在 conversation 中完成。
-- 经用户明确授权后使用多 Agent，并通过文件所有权避免并行冲突。
-- 截图审查、响应式修复、可访问性检查和安全动效。
-- 可选 APIHz 媒体搜索、本地 Poster 和视频升级。
-- `build-state.json` schema v4，以及安全的 v3→v4 原子迁移工具。
+内置 Visual Companion 只依赖 Node.js 内置模块，不要求安装 Browser 插件
+或 npm 包。它在 `127.0.0.1` 启动带随机会话密钥的只读服务，同时保留静态
+`gallery.html` 作为回退。
+
+浏览器只负责视觉展示：没有选择按钮、审批控件、表单、分析或事件收集。
+用户必须返回 conversation 明确确认。打开、刷新或截图都不算批准。
+
+这种方式可以被具备 Node.js、Shell、文件系统和浏览器访问能力的本地 coding
+agent 使用，包括 Codex、Claude Code、Cursor 和 Copilot CLI。宿主无法保持
+本地服务时，可以直接展示静态 HTML；远程环境只使用用户已经授权的端口转发。
+
+## 计划门禁
+
+完整需求确认后，Skill 先生成
+`.resume-site-work/reports/site-todo-plan.md`，展示文件范围、任务、验证和
+交付物，并等待用户明确批准。随后生成机器可验证的
+`site-implementation-plan.json`。两个计划门禁完成前不得编辑 React 源码。
+
+## 最终验收
+
+完整网站展示后提供三个选择：
+
+- `当前效果满意，完成`
+- `加强动效`
+- `提出修改`
+
+加强动效只修改动效层；局部反馈直接修复。推翻结构、排版、配色等核心决定时，
+只返回受影响的选择阶段，并重新确认需求和 TODO Plan。
 
 ## 使用
 
-安装插件后，通常直接调用总控 Skill：
+通常调用总控 Skill：
 
 ```text
 $resume-portfolio-workflow
 ```
 
-也可以在边界明确时单独调用内容或网站 Skill。网站 Skill 检测到内容包缺失或需要事实修改时，会要求先执行内容核验流程。
+边界明确时也可以直接调用：
 
-插件清单位于 `.codex-plugin/plugin.json`。
+```text
+$build-resume-portfolio-site
+```
 
-## 跨 Agent 视觉预览
-
-网站 Skill 自带纯 Node.js Visual Companion，只使用 Node 内置模块。它生成
-display-only 本地画廊，默认监听 `127.0.0.1`，并返回带随机会话密钥的完整
-URL。浏览器不会提交选择；用户必须回到 conversation 明确批准。
-
-支持具备 Node.js、Shell、文件系统和浏览器访问路径的本地 coding agent：
-
-- Codex：使用可持续运行或异步终端命令；
-- Claude Code：使用后台 Shell 任务；
-- Cursor：使用其终端后台任务；
-- Copilot CLI：使用异步 Shell；
-- 其他本地 Agent：保持前台服务器进程，或直接展示静态 HTML。
-
-自动打开浏览器失败时继续提供 URL；服务器不能存活或远程 loopback
-不可访问时，保留并展示静态 `gallery.html`。远程场景只使用用户已授权的
-端口转发，不上传简历或视觉稿。
-
-## 安全边界
-
-API 凭据只能通过运行环境变量提供，不应写入仓库。用户简历、个人素材、构建产物、缓存和 `.resume-site-work/` 状态目录均不属于插件发布内容。
+插件清单位于 `.codex-plugin/plugin.json`。用户简历、媒体、构建结果、缓存和
+`.resume-site-work/` 不属于插件发布内容；凭据只能由运行环境变量提供。

--- a/docs/superpowers/plans/2026-07-31-upfront-portfolio-design-decisions.md
+++ b/docs/superpowers/plans/2026-07-31-upfront-portfolio-design-decisions.md
@@ -1,0 +1,784 @@
+# Upfront Portfolio Design Decisions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make full portfolio discovery confirm six independent design dimensions and a human-readable TODO plan before generating one integrated React + Vite website.
+
+**Architecture:** Extend the existing display-only Visual Companion instead of adding browser-side interaction. Store six category decisions in site-design schema v3, require a separately approved Markdown TODO plan plus machine-validatable implementation plan, then replace the prototype/media/motion confirmation chain with one integrated generation transaction and a three-choice acceptance loop.
+
+**Tech Stack:** Markdown Agent Skill contracts, JSON Schema draft 2020-12, Python 3 standard-library validators and `unittest`, Node.js Visual Companion scripts, React + Vite output validation.
+
+## Global Constraints
+
+- Browser previews are independent and display-only; browser activity never selects or approves anything.
+- Full discovery order is structure, typography, color, conditional media, primary motion, secondary motion.
+- Every enabled category receives a separate browser-preview offer after tentative selection.
+- Media may be skipped only with an explicit reason.
+- Exactly one primary-motion system is selected; secondary motion supports compatible multi-selection without a fixed numeric cap.
+- Final requirements and the readable TODO plan both require explicit conversational approval before React source edits.
+- The first React candidate integrates all confirmed decisions in one generation transaction.
+- Responsive behavior, accessibility, coarse-pointer support, fallbacks, and reduced motion are mandatory engineering constraints.
+- Fast-change remains available only for bounded edits to an existing confirmed artifact.
+- Use the existing Node-only loopback Visual Companion; add no browser plugin, browser approval control, analytics, or runtime package dependency.
+- Preserve approved resume facts and authorized-media boundaries.
+
+---
+
+## File map
+
+- `tests/test_workflow_behavior_contract.py`: repository-level workflow assertions and validator integration coverage.
+- `tests/fixtures/site-design-spec-valid.json`: canonical schema-v3 full-discovery artifact.
+- `tests/fixtures/site-plan-valid.json`: canonical approved human/machine planning artifact.
+- `skills/build-resume-portfolio-site/references/site-design-spec-schema.json`: machine-readable six-decision contract.
+- `skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py`: semantic validation beyond JSON Schema.
+- `skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py`: unit coverage for category order, preview response, skip, approval, and motion selection.
+- `skills/build-resume-portfolio-site/references/site-implementation-plan-schema.json`: machine-readable plan approval contract.
+- `skills/build-resume-portfolio-site/scripts/validate_site_implementation_plan.py`: semantic validation for readable-plan path and explicit approval.
+- `skills/build-resume-portfolio-site/scripts/test_validate_site_implementation_plan.py`: plan-gate unit coverage.
+- `skills/build-resume-portfolio-site/references/site-brainstorming-contract.md`: six-category discovery transaction.
+- `skills/build-resume-portfolio-site/references/visual-style-preview-contract.md`: independent per-category Gallery rules.
+- `skills/build-resume-portfolio-site/references/site-planning-contract.md`: synchronized Markdown/JSON plan and conversational approval.
+- `skills/build-resume-portfolio-site/references/workflow-contract.md`: integrated state machine, rollback, and final acceptance loop.
+- `skills/build-resume-portfolio-site/references/artifact-layout.md`: decision galleries, `site-todo-plan.md`, and integrated snapshots.
+- `skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md`: one-pass implementation prompt that consumes all confirmed decisions.
+- `skills/build-resume-portfolio-site/scripts/validate_skill_resources.py`: integrated-stage resource registration.
+- `skills/build-resume-portfolio-site/scripts/validate_vite_project.py`: `integrated` stage validation.
+- `skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py`: integrated resource discovery coverage.
+- `skills/build-resume-portfolio-site/scripts/test_validate_vite_project.py`: integrated-stage quality and reduced-motion coverage.
+- `skills/build-resume-portfolio-site/SKILL.md`: authoritative runtime orchestration.
+- `README.md`: public workflow description.
+
+### Task 1: Lock the new workflow behavior with failing contract tests
+
+**Files:**
+- Modify: `tests/test_workflow_behavior_contract.py`
+
+**Interfaces:**
+- Consumes: approved design specification `docs/superpowers/specs/2026-07-31-upfront-portfolio-design-decisions.md`.
+- Produces: failing behavioral assertions that every later task must satisfy.
+
+- [ ] **Step 1: Add the full-discovery sequence assertion**
+
+Add a test that reads `site-brainstorming-contract.md`, finds these exact markers, and asserts their positions increase:
+
+```python
+def test_full_discovery_orders_six_independent_decisions(self) -> None:
+    contract = self.read_site_reference("site-brainstorming-contract.md").lower()
+    markers = (
+        "overall structure",
+        "typography",
+        "color system",
+        "media treatment",
+        "primary motion",
+        "secondary motion",
+        "final requirements confirmation",
+        "todo plan approval",
+    )
+    positions = [contract.index(marker) for marker in markers]
+    self.assertEqual(positions, sorted(positions))
+```
+
+Add `read_site_reference()` beside `read_skill()` so reference lookup is not duplicated.
+
+- [ ] **Step 2: Add independent preview and plan-gate assertions**
+
+```python
+def test_each_enabled_decision_gets_a_separate_preview_offer(self) -> None:
+    contract = self.read_site_reference("visual-style-preview-contract.md").lower()
+    self.assertIn("ask separately for every enabled category", contract)
+    self.assertIn("independent, not cumulative", contract)
+    self.assertIn("declining one category", contract)
+
+def test_site_skill_requires_readable_plan_approval_before_source_edits(self) -> None:
+    text = self.read_skill("build-resume-portfolio-site").lower()
+    self.assertIn("site-todo-plan.md", text)
+    self.assertIn("todo plan approval", text)
+    self.assertIn("do not edit react source", text)
+    self.assertIn("one integrated", text)
+```
+
+- [ ] **Step 3: Add final acceptance assertions**
+
+Assert the Skill contains the exact choices `当前效果满意，完成`, `加强动效`, and `提出修改`, and that the workflow contract says motion enhancement preserves structure, typography, color, and media treatment.
+
+- [ ] **Step 4: Run the new tests and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -p "test_workflow_behavior_contract.py" -v
+```
+
+Expected: FAIL because the current contracts contain one cumulative Gallery, staged prototype/media/motion confirmations, and no readable-plan approval gate.
+
+- [ ] **Step 5: Commit the failing behavior contract**
+
+```powershell
+git add -- tests/test_workflow_behavior_contract.py
+git commit -m "test: define upfront portfolio workflow"
+```
+
+### Task 2: Upgrade the site design specification to schema version 3
+
+**Files:**
+- Modify: `skills/build-resume-portfolio-site/references/site-design-spec-schema.json`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py`
+- Modify: `tests/fixtures/site-design-spec-valid.json`
+
+**Interfaces:**
+- Consumes: six decision categories and conversational approvals.
+- Produces: validated `reports/site-design-spec.json` with `decision_order`, `decisions`, `engineering_constraints`, and `requirements_approval`.
+
+- [ ] **Step 1: Replace the unit-test fixture with the wished-for v3 payload**
+
+Use this top-level shape in `valid_spec()` and the repository fixture:
+
+```python
+{
+    "schema_version": 3,
+    "spec_id": "site-spec-1",
+    "workflow_mode": "full",
+    "content_revision": 1,
+    "decision_order": [
+        "structure", "typography", "color", "media",
+        "primary_motion", "secondary_motion",
+    ],
+    "decisions": {
+        "structure": confirmed_single("editorial", "structure-1"),
+        "typography": confirmed_single("editorial-serif", "typography-1"),
+        "color": confirmed_single("ink-yellow", "color-1"),
+        "media": skipped_media("no authorized media"),
+        "primary_motion": confirmed_single("section-reveal", "primary-motion-1"),
+        "secondary_motion": confirmed_multi(
+            ["card-feedback", "text-reveal"], "secondary-motion-1"
+        ),
+    },
+    "engineering_constraints": [
+        "responsive", "accessible", "coarse-pointer",
+        "reduced-motion", "media-fallbacks",
+    ],
+    "requirements_approval": {
+        "status": "user_approved",
+        "source": "explicit_user",
+        "channel": "conversation",
+    },
+}
+```
+
+A confirmed decision contains `status`, two or more candidate objects, `recommended_candidate_id`, `tentative_selection_ids`, `selected_candidate_ids`, `preview`, and `approval`. Preview contains `offered: true`, `response: accepted|declined`, `delivery: local-gallery|static-fallback|not-requested`, and nullable `artifact`. Approval must be explicit and conversational.
+
+- [ ] **Step 2: Add failing semantic tests**
+
+Add one focused test for each rule:
+
+```python
+def test_rejects_wrong_decision_order(self) -> None:
+    payload = valid_spec()
+    payload["decision_order"][0:2] = ["typography", "structure"]
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_missing_preview_offer_for_enabled_category(self) -> None:
+    payload = valid_spec()
+    payload["decisions"]["color"]["preview"]["offered"] = False
+    result = self.run_validator(payload)
+    self.assertEqual(result.returncode, 1)
+    self.assertIn("color preview must be offered", result.stdout)
+
+def test_accepts_declined_preview_and_later_accepted_preview(self) -> None:
+    payload = valid_spec()
+    payload["decisions"]["structure"]["preview"] = {
+        "offered": True,
+        "response": "declined",
+        "delivery": "not-requested",
+        "artifact": None,
+    }
+    self.assertEqual(self.run_validator(payload).returncode, 0)
+
+def test_rejects_media_skip_without_reason(self) -> None:
+    payload = valid_spec()
+    payload["decisions"]["media"].pop("skip_reason")
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_multiple_primary_motion_selections(self) -> None:
+    payload = valid_spec()
+    decision = payload["decisions"]["primary_motion"]
+    decision["selected_candidate_ids"] = [
+        decision["candidates"][0]["id"],
+        decision["candidates"][1]["id"],
+    ]
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_accepts_multiple_compatible_secondary_motion_selections(self) -> None:
+    payload = valid_spec()
+    decision = payload["decisions"]["secondary_motion"]
+    decision["selected_candidate_ids"] = [
+        candidate["id"] for candidate in decision["candidates"]
+    ]
+    self.assertEqual(self.run_validator(payload).returncode, 0)
+
+def test_rejects_unapproved_final_requirements(self) -> None:
+    payload = valid_spec()
+    payload["requirements_approval"]["status"] = "pending"
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_browser_approval_channel(self) -> None:
+    payload = valid_spec()
+    payload["decisions"]["typography"]["approval"]["channel"] = "browser"
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_version_two_for_new_full_discovery(self) -> None:
+    payload = valid_spec()
+    payload["schema_version"] = 2
+    result = self.run_validator(payload)
+    self.assertEqual(result.returncode, 1)
+    self.assertIn("schema_version must be 3", result.stdout)
+```
+
+- [ ] **Step 3: Run validator tests and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_validate_site_design_spec.py" -v
+```
+
+Expected: FAIL because the validator requires schema version 2 and one `visual_preview` object.
+
+- [ ] **Step 4: Implement reusable decision validation**
+
+Replace `_validate_visual_preview()` with these interfaces:
+
+```python
+DECISION_ORDER = (
+    "structure", "typography", "color", "media",
+    "primary_motion", "secondary_motion",
+)
+
+def _validate_preview(preview: Any, category: str) -> list[str]:
+    if not isinstance(preview, dict):
+        return [f"{category} requires a preview record"]
+    errors: list[str] = []
+    if preview.get("offered") is not True:
+        errors.append(f"{category} preview must be offered")
+    response = preview.get("response")
+    delivery = preview.get("delivery")
+    artifact = preview.get("artifact")
+    if response not in {"accepted", "declined"}:
+        errors.append(f"{category} preview response is invalid")
+    if delivery not in {
+        "local-gallery", "static-fallback", "not-requested"
+    }:
+        errors.append(f"{category} preview delivery is invalid")
+    if response == "declined":
+        if delivery != "not-requested" or artifact is not None:
+            errors.append(f"{category} declined preview must not have an artifact")
+        return errors
+    if delivery == "not-requested":
+        errors.append(f"{category} accepted preview requires delivery")
+    normalized = str(artifact or "").replace("\\", "/")
+    path = PurePosixPath(normalized)
+    if (
+        path.is_absolute()
+        or ".." in path.parts
+        or path.parts[:3]
+        != (".resume-site-work", "style-preview", "sessions")
+        or path.parts[-1:] != ("gallery.html",)
+    ):
+        errors.append(f"{category} preview artifact must be a session gallery")
+    return errors
+
+def _validate_confirmed_decision(
+    category: str, decision: Any, *, allow_multiple: bool
+) -> list[str]:
+    if not isinstance(decision, dict) or decision.get("status") != "confirmed":
+        return [f"{category} must be confirmed"]
+    errors: list[str] = []
+    candidates = decision.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) < 2:
+        return [f"{category} requires at least two candidates"]
+    ids = [item.get("id") for item in candidates if isinstance(item, dict)]
+    if len(ids) != len(candidates) or not all(
+        isinstance(item, str) and item.strip() for item in ids
+    ) or len(ids) != len(set(ids)):
+        errors.append(f"{category} candidate IDs must be unique")
+    candidate_ids = set(ids)
+    if decision.get("recommended_candidate_id") not in candidate_ids:
+        errors.append(f"{category} recommendation must reference a candidate")
+    for field in ("tentative_selection_ids", "selected_candidate_ids"):
+        selected = decision.get(field)
+        if not isinstance(selected, list) or not selected:
+            errors.append(f"{category} {field} must be non-empty")
+            continue
+        if not allow_multiple and len(selected) != 1:
+            errors.append(f"{category} requires exactly one selected candidate")
+        if not set(selected) <= candidate_ids:
+            errors.append(f"{category} {field} must reference candidates")
+    errors.extend(_validate_preview(decision.get("preview"), category))
+    approval = decision.get("approval")
+    if not isinstance(approval, dict) or approval.get("status") != "user_approved":
+        errors.append(f"{category} requires explicit approval")
+    elif approval.get("source") != "explicit_user" or approval.get("channel") != "conversation":
+        errors.append(f"{category} approval must be explicit and conversational")
+    return errors
+
+def _validate_media_decision(decision: Any) -> list[str]:
+    if isinstance(decision, dict) and decision.get("status") == "skipped":
+        reason = decision.get("skip_reason")
+        return [] if isinstance(reason, str) and reason.strip() else [
+            "media skip requires a reason"
+        ]
+    return _validate_confirmed_decision("media", decision, allow_multiple=False)
+```
+
+Validate candidate uniqueness, selected IDs, separate preview offer, artifact containment below `.resume-site-work/style-preview/sessions/`, explicit conversation approval, single primary selection, multi secondary selection, skip reason, mandatory constraints, and final requirements approval. Return stable category-prefixed errors such as `primary_motion requires exactly one selected candidate`.
+
+- [ ] **Step 5: Replace the JSON Schema with the same v3 contract**
+
+Define `$defs.candidate`, `$defs.preview`, `$defs.approval`, `$defs.confirmedDecision`, `$defs.singleDecision`, and `$defs.skippedMedia`. Use `oneOf` for media confirmed/skipped and `maxItems: 1` only for the selected IDs of single-choice categories. Do not add a maximum to `secondary_motion.selected_candidate_ids`.
+
+- [ ] **Step 6: Run unit and repository behavior tests**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_validate_site_design_spec.py" -v
+python -m unittest discover -s tests -p "test_workflow_behavior_contract.py" -v
+```
+
+Expected: schema-validator tests PASS; workflow tests remain RED only for contracts and planning not yet changed.
+
+- [ ] **Step 7: Commit schema v3**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/references/site-design-spec-schema.json skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py tests/fixtures/site-design-spec-valid.json
+git commit -m "feat: validate six portfolio decisions"
+```
+
+### Task 3: Require an approved readable TODO plan
+
+**Files:**
+- Modify: `skills/build-resume-portfolio-site/references/site-implementation-plan-schema.json`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_site_implementation_plan.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_validate_site_implementation_plan.py`
+- Modify: `tests/fixtures/site-plan-valid.json`
+
+**Interfaces:**
+- Consumes: approved schema-v3 `site-design-spec.json` and `.resume-site-work/reports/site-todo-plan.md`.
+- Produces: schema-v2 `site-implementation-plan.json` proving the readable plan was shown and explicitly approved.
+
+- [ ] **Step 1: Add v2 plan fields to the wished-for fixture**
+
+```json
+{
+  "schema_version": 2,
+  "design_spec_id": "site-spec-1",
+  "todo_plan": ".resume-site-work/reports/site-todo-plan.md",
+  "todo_plan_approval": {
+    "status": "user_approved",
+    "source": "explicit_user",
+    "channel": "conversation"
+  },
+  "generation_mode": "one-integrated-site",
+  "strategy": "single-agent"
+}
+```
+
+Keep the existing task, dependency, ownership, rollback, and snapshot fields. Change the canonical task from `prototype-shell` to `integrated-site` and the snapshot target to `versions/v1-integrated`.
+
+- [ ] **Step 2: Add failing plan-gate tests**
+
+```python
+def test_rejects_missing_readable_todo_plan_path(self) -> None:
+    payload = valid_plan()
+    payload.pop("todo_plan")
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_todo_plan_outside_reports(self) -> None:
+    payload = valid_plan()
+    payload["todo_plan"] = "docs/site-todo-plan.md"
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_unapproved_todo_plan(self) -> None:
+    payload = valid_plan()
+    payload["todo_plan_approval"]["status"] = "pending"
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_browser_todo_plan_approval(self) -> None:
+    payload = valid_plan()
+    payload["todo_plan_approval"]["channel"] = "browser"
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_non_integrated_generation_mode(self) -> None:
+    payload = valid_plan()
+    payload["generation_mode"] = "prototype-first"
+    self.assertEqual(self.run_validator(payload).returncode, 1)
+
+def test_rejects_version_one(self) -> None:
+    payload = valid_plan()
+    payload["schema_version"] = 1
+    result = self.run_validator(payload)
+    self.assertEqual(result.returncode, 1)
+    self.assertIn("schema_version must be 2", result.stdout)
+```
+
+- [ ] **Step 3: Run plan tests and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_validate_site_implementation_plan.py" -v
+```
+
+Expected: FAIL because current plans have no readable-plan or explicit-approval fields.
+
+- [ ] **Step 4: Implement plan v2 validation**
+
+Add required fields `todo_plan`, `todo_plan_approval`, and `generation_mode`. Require the normalized path to equal `.resume-site-work/reports/site-todo-plan.md`; require `user_approved`, `explicit_user`, and `conversation`; require `generation_mode == "one-integrated-site"`; preserve all existing multi-agent and file-overlap validation.
+
+- [ ] **Step 5: Update JSON Schema and run tests GREEN**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_validate_site_implementation_plan.py" -v
+```
+
+Expected: all plan-validator tests PASS.
+
+- [ ] **Step 6: Commit the planning gate**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/references/site-implementation-plan-schema.json skills/build-resume-portfolio-site/scripts/validate_site_implementation_plan.py skills/build-resume-portfolio-site/scripts/test_validate_site_implementation_plan.py tests/fixtures/site-plan-valid.json
+git commit -m "feat: require approved site todo plan"
+```
+
+### Task 4: Rewrite discovery and preview contracts around independent categories
+
+**Files:**
+- Modify: `skills/build-resume-portfolio-site/references/site-brainstorming-contract.md`
+- Modify: `skills/build-resume-portfolio-site/references/visual-style-preview-contract.md`
+- Modify: `skills/build-resume-portfolio-site/references/site-planning-contract.md`
+- Modify: `skills/build-resume-portfolio-site/references/artifact-layout.md`
+- Modify: `tests/test_visual_companion.py`
+
+**Interfaces:**
+- Consumes: schema-v3 decisions and the unchanged `launch.cjs`/`stop.cjs` runtime.
+- Produces: one independent Gallery draft/session per accepted category and one readable plan artifact.
+
+- [ ] **Step 1: Add failing package-language tests**
+
+Extend `VisualCompanionPackageTests` to require category-neutral placeholders and conversation copy:
+
+```python
+self.assertIn("<!-- preview-category -->", text)
+self.assertIn("<!-- visual-candidates -->", text)
+self.assertIn("return to the conversation", text)
+self.assertNotIn("approval", interactive_attributes)
+```
+
+Keep the existing form/button/data-choice prohibitions.
+
+- [ ] **Step 2: Run Visual Companion tests and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -p "test_visual_companion.py" -v
+```
+
+Expected: FAIL because the gallery shell currently exposes only the old visual-directions placeholder.
+
+- [ ] **Step 3: Define the independent Gallery transaction**
+
+In `visual-style-preview-contract.md`, specify category IDs `structure`, `typography`, `color`, `media`, `primary-motion`, and `secondary-motion`; draft paths `.resume-site-work/style-preview/drafts/<category>/<draft-id>/gallery.html`; and separate launch sessions. State verbatim that the Agent must `ask separately for every enabled category`, previews are `independent, not cumulative`, and `declining one category` does not suppress later offers.
+
+- [ ] **Step 4: Define discovery and plan gates**
+
+Rewrite `site-brainstorming-contract.md` with the exact ordered markers from Task 1. Rewrite `site-planning-contract.md` so it creates `site-todo-plan.md`, shows it in conversation, waits for approval, then writes/validates JSON v2. Update artifact layout with category draft/session paths, `site-todo-plan.md`, and `versions/v1-integrated`.
+
+- [ ] **Step 5: Generalize the gallery shell without adding interaction**
+
+Replace `<!-- visual-directions -->` with `<!-- preview-category -->` and `<!-- visual-candidates -->`; use neutral copy that applies to layout, typography, color, media, and motion samples. Do not change server, launcher, token, or stop semantics.
+
+- [ ] **Step 6: Run Visual Companion and behavior tests**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -p "test_visual_companion.py" -v
+python -m unittest discover -s tests -p "test_workflow_behavior_contract.py" -v
+```
+
+Expected: Visual Companion tests PASS; behavior tests remain RED only for Skill/state-machine integration.
+
+- [ ] **Step 7: Commit the independent-preview contracts**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/references/site-brainstorming-contract.md skills/build-resume-portfolio-site/references/visual-style-preview-contract.md skills/build-resume-portfolio-site/references/site-planning-contract.md skills/build-resume-portfolio-site/references/artifact-layout.md skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html tests/test_visual_companion.py
+git commit -m "docs: define independent design previews"
+```
+
+### Task 5: Add the integrated generation resource and validator stage
+
+**Files:**
+- Create: `skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_skill_resources.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_vite_project.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_validate_vite_project.py`
+
+**Interfaces:**
+- Consumes: approved copy, schema-v3 design spec, approved TODO plan, validated JSON plan, authorized media, and design intelligence.
+- Produces: complete `.resume-site-work/site` validated with `--stage integrated`.
+
+- [ ] **Step 1: Add failing integrated resource and stage tests**
+
+Require `validate_skill_resources.py --mode runtime --stage integrated` to resolve `generate-integrated-site`, design catalog, media/motion contracts, and capture resources. Add a Vite validator test proving `integrated` requires all normal quality checks plus a `prefers-reduced-motion: reduce` rule.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_validate_skill_resources.py" -v
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_validate_vite_project.py" -v
+```
+
+Expected: FAIL with unknown/missing `integrated` stage and resource.
+
+- [ ] **Step 3: Register the integrated stage**
+
+Add `"generate-integrated-site": "prompts/01-generate-integrated-site.md"` and an `integrated` stage bundle. Add `integrated` to `STAGES` and `MOTION_STAGES` in `validate_vite_project.py` so reduced-motion handling is mandatory for the first complete candidate.
+
+- [ ] **Step 4: Write the integrated generation prompt**
+
+The prompt must require these inputs and outputs explicitly:
+
+```text
+Inputs: normalized-resume.json, approved-copy.json, site-design-spec.json,
+site-todo-plan.md, site-implementation-plan.json, design-intelligence.json,
+authorized media inventory when present.
+
+Output: one complete React + Vite site implementing structure, typography,
+color, media treatment, primary motion, compatible secondary motion,
+responsive layout, accessibility, coarse-pointer behavior, fallbacks, and
+reduced motion in the same source transaction.
+```
+
+Remove prototype-language, deferred color/media/motion language, and intermediate confirmation instructions from the new prompt. Retain factual integrity, centralized content data, semantic HTML, approximately 1700px desktop composition, media fallbacks, and build requirements.
+
+- [ ] **Step 5: Run focused tests GREEN**
+
+Run the two focused commands from Step 2. Expected: PASS.
+
+- [ ] **Step 6: Commit integrated generation support**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md skills/build-resume-portfolio-site/scripts/validate_skill_resources.py skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py skills/build-resume-portfolio-site/scripts/validate_vite_project.py skills/build-resume-portfolio-site/scripts/test_validate_vite_project.py
+git commit -m "feat: validate integrated portfolio generation"
+```
+
+### Task 6: Replace the staged runtime workflow with one integrated transaction
+
+**Files:**
+- Modify: `skills/build-resume-portfolio-site/SKILL.md`
+- Modify: `skills/build-resume-portfolio-site/references/workflow-contract.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: six confirmed decisions and approved planning artifacts from Tasks 2–4.
+- Produces: runtime states `design_<category>_selecting`, `requirements_waiting_confirmation`, `todo_plan_waiting_confirmation`, `integrated_generating`, `integrated_auditing`, `integrated_waiting_confirmation`, `motion_enhancing`, and `complete`.
+
+- [ ] **Step 1: Run the Task 1 behavior suite immediately before edits**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -p "test_workflow_behavior_contract.py" -v
+```
+
+Expected: remaining failures identify the old staged Skill and workflow state machine.
+
+- [ ] **Step 2: Rewrite the discovery gate in `SKILL.md`**
+
+Require the six-category transaction, per-category preview question, schema-v3 validation, consolidated requirements approval, readable TODO plan creation, JSON v2 validation, and explicit plan approval. Preserve the rule that no React source edit occurs before both approvals.
+
+- [ ] **Step 3: Replace Stages 1–4 with integrated generation and audit**
+
+Use this runtime sequence:
+
+```text
+requirements_waiting_confirmation --confirm-->
+todo_plan_generating -> todo_plan_waiting_confirmation --approve-->
+integrated_generating -> integrated_auditing ->
+integrated_waiting_confirmation
+```
+
+Integrated generation consumes `01-generate-integrated-site.md`, validates with `--stage integrated`, builds, promotes, captures desktop/tablet/mobile plus reduced-motion states, performs at most two bounded local repair rounds, and snapshots `versions/v1-integrated`.
+
+- [ ] **Step 4: Implement the three-choice acceptance loop**
+
+Document exact outcomes:
+
+```text
+当前效果满意，完成 -> complete
+加强动效 -> motion_enhancing -> integrated_waiting_confirmation
+提出修改 -> bounded repair OR return to the invalidated core decision
+```
+
+Motion enhancement restores `versions/v1-integrated`, changes only the motion layer, revalidates/builds/captures, and preserves content, structure, typography, color, and media. A core-decision reversal invalidates downstream decision evidence, requirements approval, TODO-plan approval, and implementation plan.
+
+- [ ] **Step 5: Preserve optional media search and video upgrade as side transactions**
+
+Retain APIHz and video-upgrade behavior, but rebase their rollback language on the last confirmed integrated or motion-enhanced snapshot rather than `v1-prototype` through `v5-motion-enhanced-poster`.
+
+- [ ] **Step 6: Update README usage narrative**
+
+Describe six optional browser openings, conversational approvals, the TODO plan gate, one-pass React generation, and final accept/enhance/modify choices. State that preview samples are independent and not final-source fragments.
+
+- [ ] **Step 7: Run behavior tests GREEN**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -p "test_workflow_behavior_contract.py" -v
+```
+
+Expected: all workflow behavior tests PASS.
+
+- [ ] **Step 8: Commit runtime orchestration**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/SKILL.md skills/build-resume-portfolio-site/references/workflow-contract.md README.md
+git commit -m "feat: generate portfolio after plan approval"
+```
+
+### Task 7: Close cross-resource gaps and regressions
+
+**Files:**
+- Modify only when a failing test proves it necessary: `skills/build-resume-portfolio-site/references/creative-direction-contract.md`
+- Modify only when a failing test proves it necessary: `skills/build-resume-portfolio-site/references/media-art-direction-contract.md`
+- Modify only when a failing test proves it necessary: `skills/build-resume-portfolio-site/references/motion-production-contract.md`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_installed_skill_workflow.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_synced_workflow_baseline.py`
+
+**Interfaces:**
+- Consumes: completed runtime contracts.
+- Produces: no stale staged-confirmation or schema-v2 assumptions in packaged and installed-workflow tests.
+
+- [ ] **Step 1: Search for stale workflow vocabulary**
+
+Run:
+
+```powershell
+Get-ChildItem skills/build-resume-portfolio-site,tests -Recurse -File | Select-String -Pattern "schema-version-2|schema_version.*2|prototype_waiting_confirmation|media_direction_waiting_confirmation|motion_waiting_confirmation|v1-prototype|visual_preview"
+```
+
+Expected: list every remaining staged assumption; classify each as migration documentation, optional enhancement compatibility, or stale runtime behavior.
+
+- [ ] **Step 2: Add failing installed/sync assertions**
+
+Require the installed Skill workflow tests to find schema v3, `site-todo-plan.md`, `one integrated`, and all three final choices, while rejecting old prototype/media confirmation gates in the main generation path.
+
+- [ ] **Step 3: Run installed-workflow tests and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_installed_skill_workflow.py" -v
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_synced_workflow_baseline.py" -v
+```
+
+Expected: FAIL until the source and installed copies are synchronized.
+
+- [ ] **Step 4: Remove only proven stale assumptions**
+
+Update referenced contracts when their old staged input/output descriptions contradict integrated generation. Preserve reusable media inventory, creative-freedom, motion safety, APIHz isolation, and video fallback semantics.
+
+- [ ] **Step 5: Run the entire source test matrix**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests -v
+python -m unittest discover -s skills/build-resume-portfolio-site/scripts -p "test_*.py" -v
+node --check skills/build-resume-portfolio-site/scripts/visual_companion/server.cjs
+node --check skills/build-resume-portfolio-site/scripts/visual_companion/launch.cjs
+node --check skills/build-resume-portfolio-site/scripts/visual_companion/stop.cjs
+```
+
+Expected: all Python tests PASS and all Node syntax checks exit 0.
+
+- [ ] **Step 6: Commit regression cleanup**
+
+Stage only files changed because of failing tests, then commit:
+
+```powershell
+git commit -m "test: align packaged portfolio workflow"
+```
+
+### Task 8: Validate, synchronize the installed Skill, and update the Draft PR
+
+**Files:**
+- Synchronize source files from `skills/build-resume-portfolio-site/` to `C:/Users/86135/.codex/skills/build-resume-portfolio-site/` after approval for the external write.
+- No generated workspace artifacts are committed.
+
+**Interfaces:**
+- Consumes: verified source Skill at current branch HEAD.
+- Produces: matching installed Skill and an updated remote Draft PR.
+
+- [ ] **Step 1: Run source resource validation**
+
+Run:
+
+```powershell
+$env:PYTHONUTF8=1
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage discovery
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage planning
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage integrated
+python C:/Users/86135/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/build-resume-portfolio-site
+```
+
+Expected: every validator exits 0.
+
+- [ ] **Step 2: Synchronize only the Skill package**
+
+After obtaining filesystem approval, copy the verified contents of `skills/build-resume-portfolio-site/` over the installed Skill directory without touching unrelated skills. Exclude `__pycache__`, generated sessions, tests' temporary files, and repository-only docs.
+
+- [ ] **Step 3: Verify source/installed parity**
+
+Hash every packaged file in the source and installed directories using relative paths. Expected: identical file sets and hashes for all packaged resources.
+
+- [ ] **Step 4: Run installed resource and workflow tests**
+
+Run the installed quick validator plus the installed workflow/resource discovery tests. Expected: PASS with schema v3, integrated stage, six preview offers, and TODO-plan approval present.
+
+- [ ] **Step 5: Inspect final Git scope**
+
+Run:
+
+```powershell
+git status -sb
+git diff --check master...HEAD
+git log --oneline master..HEAD
+```
+
+Expected: clean worktree, no whitespace errors, and only the approved design/workflow changes.
+
+- [ ] **Step 6: Push and confirm Draft PR**
+
+Push `codex/portable-visual-companion`, then confirm PR #1 remains open as a Draft with base `master` and the new HEAD. Update its body to describe six independent decision previews, schema v3, the approved TODO-plan gate, integrated generation, and the final acceptance loop.
+
+## Final verification checklist
+
+- [ ] Every new validator behavior was observed failing before implementation.
+- [ ] Schema v3 accepts declined previews without suppressing later offers.
+- [ ] Media skip requires an explicit reason.
+- [ ] Primary motion is singular and secondary motion is compatible multi-select.
+- [ ] The readable TODO plan and JSON plan approvals are both required.
+- [ ] React source remains untouched before final requirements and plan approval.
+- [ ] The first generated site integrates every confirmed dimension.
+- [ ] Final choices are exactly accept, strengthen motion, or modify.
+- [ ] Source and installed Skill packages match.
+- [ ] Full Python, Node syntax, resource, and quick-validation suites pass.

--- a/docs/superpowers/specs/2026-07-31-upfront-portfolio-design-decisions.md
+++ b/docs/superpowers/specs/2026-07-31-upfront-portfolio-design-decisions.md
@@ -1,0 +1,137 @@
+# Upfront Portfolio Design Decisions
+
+## Goal
+
+Change full site discovery so the user confirms the complete design intent before React source generation. Discovery must cover structure, typography, color, conditional media treatment, primary motion, and secondary motion. Each decision may receive its own independent browser preview. After the requirements are confirmed, the Skill must generate and obtain approval for a readable TODO plan before producing the website once.
+
+## Scope
+
+This design applies to new sites and changes that alter structure, visual direction, interaction architecture, or implementation strategy. Bounded existing-site changes continue to use the fast-change route unless their scope expands into one of these design decisions.
+
+The browser remains a display-only companion. Selection and approval occur only in the conversation.
+
+## Discovery sequence
+
+Full discovery uses this fixed order:
+
+1. Overall structure
+2. Typography and typesetting character
+3. Color system
+4. Media treatment, only when authorized media exists or the user wants a media strategy
+5. Primary motion
+6. Secondary motion
+7. Final requirements confirmation
+8. TODO plan generation and approval
+9. One-pass website generation
+
+Responsive behavior, accessibility, coarse-pointer support, and reduced-motion behavior are engineering constraints rather than optional user choices.
+
+## Decision transaction
+
+Each enabled design category follows the same transaction:
+
+1. Derive two or three materially different candidates from the approved content and constraints.
+2. Explain the candidates, recommend one, and state the important trade-offs.
+3. Receive a tentative conversational selection.
+4. Ask, in a separate prompt, whether the user wants to open a browser for this category's visual preview.
+5. If accepted, generate and present an independent display-only gallery. If declined, record the decline and continue text-only.
+6. Receive explicit confirmation, revision, or rejection in the conversation.
+7. Lock the confirmed decision before entering the next category.
+
+The preview-offer question is required even when the candidates can be described in text. Do not infer consent from a previous preview: the user decides separately for every category. Do not repeatedly offer the same category after the user declines.
+
+## Independent preview model
+
+The six previews are independent, not cumulative. Each gallery isolates one decision dimension using a neutral demonstration baseline:
+
+- structure previews compare composition, hierarchy, navigation, and content density;
+- typography previews compare type character, scale, rhythm, and reading texture;
+- color previews compare background, foreground, accent, contrast, and semantic color roles;
+- media previews compare framing, cropping, sequencing, fallback, and image-to-interface relationships;
+- primary-motion previews compare the main temporal or scroll narrative;
+- secondary-motion previews compare compatible local feedback and atmosphere effects.
+
+An independent preview is evidence for a decision, not reusable React source and not a fragment to be concatenated into the final website. The gallery shows all candidates and may visually mark the tentative selection, but it contains no selection controls, approval buttons, analytics, or event collection.
+
+Browser launch failure is non-blocking. The Skill must provide the authenticated local URL when available and the absolute static HTML fallback. Browser visits, reloads, screenshots, or automatic opening never advance workflow state.
+
+## Primary and secondary motion
+
+Primary motion defines the site's dominant motion system, such as scroll-driven narrative, sectional transitions, spatial parallax, or staged reveals. Exactly one primary system is selected so multiple top-level timelines do not compete for control.
+
+Secondary motion provides local response and atmosphere, such as button feedback, card hover, text reveal, cursor response, background particles, or light media parallax. The user may select multiple secondary effects without a fixed numeric cap. Before presenting them, the Skill filters candidates for compatibility with the primary motion, controller ownership, mobile/coarse-pointer behavior, performance, cleanup, fallback, and reduced-motion behavior.
+
+## Requirements package
+
+After all enabled categories are confirmed, the Skill writes a schema-version-3 site design specification containing:
+
+- all candidates, recommendation, tentative selection, and final selection for each category;
+- the category's conversational approval evidence;
+- whether the browser preview was offered, accepted, declined, or unavailable;
+- gallery and launch evidence when a preview was produced;
+- an explicit media-stage skip reason when applicable;
+- primary/secondary motion compatibility results;
+- required responsive, accessibility, fallback, and reduced-motion constraints.
+
+The Skill then presents a consolidated requirements summary. The user must explicitly confirm that summary before planning begins. Changing a core decision invalidates the consolidated confirmation and any existing implementation plan.
+
+## TODO plan gate
+
+After final requirements confirmation, the Skill generates two synchronized planning artifacts:
+
+1. A concise, human-readable TODO plan covering content mapping, page structure, design system, media, primary and secondary motion, component/file ownership, responsive behavior, accessibility, build verification, screenshot review, rollback, and final delivery.
+2. A machine-validatable `site-implementation-plan.json` containing exact files, dependencies, interfaces, acceptance criteria, verification commands, rollback baseline, and snapshot target.
+
+The Skill shows the TODO plan, relevant file scope, verification strategy, and expected artifacts in the conversation. React source must not be created or edited until the user explicitly approves the plan and the JSON plan validates. A changed requirement requires regenerating and reapproving both artifacts.
+
+## One-pass website generation
+
+After plan approval, the Skill generates the complete React + Vite website in one implementation transaction. Structure, typography, color, media treatment, primary motion, and secondary motion are applied together from the approved requirements package.
+
+The implementation may run automated validation, build, responsive screenshots, accessibility checks, and bounded local repairs without intermediate design confirmation. It must not silently select a different design direction or reopen completed discovery decisions.
+
+The first user-facing website candidate is the complete integrated site rather than a sequence of prototype, media-direction, and motion confirmation stages.
+
+## Final acceptance loop
+
+After the integrated site passes validation and is presented, offer three outcomes:
+
+1. `当前效果满意，完成`
+2. `加强动效`
+3. `提出修改`
+
+`加强动效` preserves approved content, structure, typography, color, and media treatment. It reopens only primary/secondary motion planning and implementation against the last valid integrated snapshot.
+
+`提出修改` routes bounded feedback to local repair. Feedback that reverses a core design decision returns to that decision category, invalidates downstream requirements and plans, and requires a new requirements confirmation and TODO-plan approval before regeneration.
+
+## State and rollback
+
+The workflow state records the active category, category decisions, preview-offer results, final requirements confirmation, TODO-plan approval, implementation attempt, last valid integrated preview, and last confirmed artifact.
+
+Failures preserve the last valid artifact:
+
+- preview failure falls back to static HTML or text-only confirmation;
+- planning failure prevents source edits;
+- build or screenshot failure retains the previous valid preview and permits bounded repair;
+- motion enhancement begins from the last valid integrated snapshot;
+- a core decision change invalidates only its downstream decisions and artifacts.
+
+## Validation strategy
+
+Behavior and schema tests must prove that:
+
+- categories occur in the required order;
+- the media category can be skipped only with an explicit reason;
+- every enabled category asks separately whether to open a browser preview;
+- declining one preview does not suppress later preview offers;
+- all galleries remain display-only and independent;
+- primary motion is singular and secondary motion supports compatible multi-selection;
+- final requirements confirmation is required before planning;
+- a readable TODO plan and valid JSON plan both exist and receive explicit approval before source edits;
+- the first generated React candidate integrates all confirmed decisions;
+- motion enhancement preserves non-motion decisions;
+- core-decision changes invalidate and regenerate downstream planning artifacts.
+
+## Migration
+
+Schema-version-2 discovery reports remain readable evidence but do not satisfy the new full-discovery gate. Existing confirmed sites may continue through a validated bounded fast-change route. A new full design or regenerated site must use schema version 3 and the new requirements and TODO-plan approvals; the Skill must not fabricate missing approvals during migration.

--- a/skills/build-resume-portfolio-site/SKILL.md
+++ b/skills/build-resume-portfolio-site/SKILL.md
@@ -1,279 +1,189 @@
 ---
 name: build-resume-portfolio-site
-description: Create or redesign runnable React + Vite resume and portfolio websites from resume content, portfolio materials, visual references, or screenshots. Use when Codex needs to build a content-driven portfolio prototype, apply a reference-derived visual style, repair local visual defects from responsive screenshots, add restrained motion, or resume this staged workflow.
+description: Use when creating or redesigning a runnable React + Vite resume or portfolio site from approved resume content, portfolio materials, visual references, screenshots, or an existing confirmed site.
 ---
 
 # Build Resume Portfolio Site
 
-Build one directly runnable React + Vite portfolio through four controlled stages. Preserve user facts, edit one source project, and retain the last confirmed source snapshot.
+Confirm the complete design intent and implementation plan before generating
+one integrated React + Vite portfolio. Preserve user facts, edit one source
+project, and retain the last valid source snapshot.
 
 ## Start or resume
 
 1. Resolve `SKILL_ROOT` as this Skill directory.
-2. Read `references/workflow-contract.md`, `references/artifact-layout.md`, `references/content-preflight-routing-contract.md`, `references/site-brainstorming-contract.md`, `references/visual-style-preview-contract.md`, `references/site-planning-contract.md`, `references/react-vite-output-contract.md`, `references/reference-library-contract.md`, `references/design-intelligence-contract.md`, `references/creative-direction-contract.md`, and `references/apihz-media-contract.md` completely. When the user explicitly authorizes multi-agent implementation, also read `references/multi-agent-implementation-contract.md` completely before dispatch.
-3. Create `.resume-site-work/` in the active user workspace or load `build-state.json`. The active state schema is version `4`. A version-3 state may be migrated only with `scripts/migrate_build_state.py` into a distinct output file; reject every other old schema and never infer a migration.
-4. Apply content preflight before a new Stage 1 build, when a new resume/JD/claim is supplied, or when the user requests factual/copy changes. Skip it only to resume an existing confirmed site for visual, media, motion, responsive, accessibility, or frontend-only work.
-5. For content preflight, run:
+2. Read `references/workflow-contract.md`, `references/artifact-layout.md`,
+   `references/content-preflight-routing-contract.md`,
+   `references/site-brainstorming-contract.md`,
+   `references/visual-style-preview-contract.md`,
+   `references/site-planning-contract.md`,
+   `references/react-vite-output-contract.md`,
+   `references/design-intelligence-contract.md`,
+   `references/creative-direction-contract.md`,
+   `references/reference-library-contract.md`, and
+   `references/apihz-media-contract.md` completely. Read specialized media,
+   screenshot, motion, or multi-agent contracts only when entering those paths.
+3. Create `.resume-site-work/` in the active workspace or load
+   `build-state.json`. Keep state schema version `4`; do not fabricate missing
+   schema-v3 design or schema-v2 planning approvals for older work.
+4. Apply content preflight for a new site, new resume/JD/claim, or copy change:
 
 ```powershell
 python "$SKILL_ROOT\scripts\validate_content_handoff.py" --workspace-root "."
 ```
 
-   - On `CONTENT_READY` (exit `0`), consume the approved package directly.
-   - On `ROUTE_REQUIRED` (exit `2`), **REQUIRED SUB-SKILL:** Use `resume-content-intelligence`. Wait for content approval and handoff, then rerun the validator.
-   - On `CONTENT_INVALID` (exit `1`), do not edit source, state, preview, or snapshots. Use the content Skill to repair or revise the package, then rerun validation.
-6. Normalize only authorized links and local media that are outside the content package. Do not silently rewrite approved copy, renormalize approved facts, or promote draft/inferred claims.
-7. Use `.resume-site-work\site` as the only editable React + Vite project. Do not create a parallel standalone HTML page.
-8. Resume the recorded stage. Load only the resources required by that stage.
+   - `CONTENT_READY` continues.
+   - `ROUTE_REQUIRED` requires `resume-content-intelligence`, its user approval,
+     and a new handoff before retrying.
+   - `CONTENT_INVALID` freezes source, preview, snapshots, and state until fixed.
+5. Use `.resume-site-work/site` as the only editable React + Vite project. A
+   discovery Gallery is evidence, never a second website source.
 
-## Discovery and implementation-plan gate
+## Full discovery gate
 
-For a new site or structural, strategic, visual-direction, interaction-family,
-or implementation-strategy change:
+Use the full route for a new site or a change to audience, overall structure,
+visual thesis, interaction architecture, or implementation strategy.
 
 1. Validate `discovery` resources.
-2. Inspect approved content, authorized media, references, and existing state.
-3. Ask one question at a time; each question must be decision-bearing.
-4. Compare two or three materially different layout or experience families.
-5. Follow `references/visual-style-preview-contract.md`. Create one
-   display-only `gallery.html` outside `.resume-site-work\site`; use approved
-   content to show every alternative at the fidelity needed for the decision.
-6. Run `scripts\visual_companion\launch.cjs` with the workspace root and
-   gallery path. Give the user the complete authenticated URL and the absolute
-   static HTML fallback. Automatic-open failure is non-blocking; when the
-   server cannot remain alive, continue with the static file.
-7. Ask the user to select and explicitly approve a candidate in the
-   conversation. Approval remains in the conversation: browser activity,
-   opening the URL, reloads, and screenshots never select a candidate or
-   advance workflow state.
-8. Write schema-version-2
-   `.resume-site-work\reports\site-design-spec.json`, validate it with
-   `scripts\validate_site_design_spec.py`, show the recommendation and
-   trade-offs, and preserve the conversational approval evidence.
-9. Validate `planning` resources.
-10. Write `.resume-site-work\reports\site-implementation-plan.json` with exact
-   files, dependencies, interfaces, acceptance, verification, rollback, and
-   snapshot target. Validate it with
-   `scripts\validate_site_implementation_plan.py`.
-11. Select the implementation strategy, then enter Stage 1 or the relevant
-   confirmed-stage transaction.
-
-Do not edit React source before the site design specification is explicitly
-approved and the site implementation plan validates.
-
-For a bounded existing-site change, require a validated
-`reports/workflow-route.json` with route `site-fast-change`, exact affected
-files, verification, confirmed artifact, and rollback baseline. Preserve the
-approved content, structure, visual thesis, and interaction architecture. If
-scope expands, stop edits and return to the full discovery gate.
-
-An explicitly migrated version-3 state with a valid confirmed snapshot may
-enter `fast-change-eligible` mode without retroactively inventing discovery or
-planning approval. It still uses the fast-change route only when the requested
-edit satisfies every bounded-change condition above.
-
-No external Superpowers skill is required at runtime.
-
-## Resource and project checks
-
-Before each stage, run:
+2. Inspect approved content, authorized media, references, and confirmed state.
+3. Ask one question at a time and complete these categories in exact order:
+   overall structure, typography, color system, conditional media treatment,
+   primary motion, and secondary motion.
+4. For every enabled category, compare candidates, recommend one, receive a
+   tentative choice, then separately ask whether to open a browser preview.
+5. On acceptance, follow `visual-style-preview-contract.md`, create an
+   independent display-only `gallery.html`, run `launch.cjs --open`, and give
+   the user the complete authenticated URL plus the absolute static HTML fallback. On decline, continue text-only. Previous consent never applies to
+   the next category.
+6. Receive final category confirmation in the conversation. Approval remains in the conversation: browser visits, reloads, screenshots, and launch events
+   do not select, approve, or advance state.
+7. Media may be skipped only with an explicit reason. Select exactly one
+   primary-motion system. Secondary motion may contain multiple compatible
+   effects without a fixed numeric cap.
+8. Summarize all decisions and mandatory responsive, accessibility,
+   coarse-pointer, fallback, and reduced-motion constraints. Obtain final
+   requirements confirmation.
+9. Write schema-version-3
+   `.resume-site-work/reports/site-design-spec.json` and validate it:
 
 ```powershell
-python "$SKILL_ROOT\scripts\validate_skill_resources.py" --mode runtime --stage <discovery|planning|prototype|media-direction|screenshot|motion>
+python "$SKILL_ROOT\scripts\validate_site_design_spec.py" `
+  ".resume-site-work\reports\site-design-spec.json"
 ```
 
-Continue only on exit `0`. Exit `2` means approved stage material is unavailable; exit `1` means malformed or missing resources. Report the exact resource and stop instead of substituting a generic prompt, template, or style.
+## TODO and implementation-plan gate
 
-After every source edit, validate `.resume-site-work\site`:
+After final requirements approval:
+
+1. Validate `planning` resources.
+2. Write `.resume-site-work/reports/site-todo-plan.md` with readable checkbox
+   tasks for content, structure, typography, color, media, primary and secondary
+   motion, file boundaries, responsive/accessibility work, validation, build,
+   screenshots, rollback, and delivery.
+3. Show the TODO plan, exact file scope, verification, and expected artifacts.
+4. Wait for explicit TODO plan approval in the conversation.
+5. Write schema-version-2
+   `.resume-site-work/reports/site-implementation-plan.json` with
+   `generation_mode: one-integrated-site`, exact tasks, dependencies, files,
+   interfaces, acceptance, verification, rollback, and `versions/v1-integrated`.
+6. Validate the plan:
 
 ```powershell
-python "$SKILL_ROOT\scripts\validate_vite_project.py" ".resume-site-work\site" --stage <prototype|styled|refined|motion>
+python "$SKILL_ROOT\scripts\validate_site_implementation_plan.py" `
+  ".resume-site-work\reports\site-implementation-plan.json"
 ```
 
-Then run `npm run build` from `.resume-site-work\site`. If dependencies are missing, ask for approval before running `npm install`; do not silently switch to CDN React, standalone HTML, or another framework. Only after validation and build succeed:
-
-- atomically replace `.resume-site-work\preview\dist` with `.resume-site-work\site\dist`;
-- set the active preview to `.resume-site-work\preview\dist\index.html`;
-- create an immutable source snapshot with `scripts\snapshot_vite_project.py`;
-- update `current_artifact` and `current_preview` in state.
-
-Keep the previous valid preview active when validation or build fails. For repeat attempts, add `-r2`, `-r3`, and so on to the snapshot directory rather than overwriting it.
+Do not edit React source before final requirements approval, explicit TODO plan
+approval, and successful JSON plan validation. A changed core decision
+invalidates final requirements approval and both planning artifacts.
 
 ## Select the implementation strategy
 
-Choose the implementation strategy after scope and design intent are approved,
-the site implementation plan validates, and before editing source:
+Choose only after the plan gate:
 
-- use `single-agent` for local or tightly coupled changes;
-- use `fresh-agent-sequential` when fresh contexts help but tasks form a
-  dependency chain;
-- use `parallel-wave` only for independently useful tasks with disjoint file
-  ownership.
+- `single-agent` for local or tightly coupled work;
+- `fresh-agent-sequential` for an authorized dependency chain;
+- `parallel-wave` only for authorized independent tasks with disjoint files.
 
-Multi-agent execution requires explicit user authorization. It does not add a
-workflow stage or confirmation gate. The main agent remains the visual director
-and integration owner; do not divide pages merely to maximize agent count.
+Multi-agent execution requires explicit user authorization and a validated
+`multi-agent-implementation.json`. The main agent owns shared files, state,
+integration, preview promotion, snapshots, and publication.
 
-For either multi-agent strategy, read
-`references/multi-agent-implementation-contract.md`, write
-`reports/multi-agent-implementation.json`, and validate it before dispatch:
+## Generate one integrated website
 
-```powershell
-python "$SKILL_ROOT\scripts\validate_multi_agent_plan.py" `
-  ".resume-site-work\reports\multi-agent-implementation.json"
-```
-
-Require bounded task packets, no overlapping file ownership in parallel waves,
-shared-file ownership by the integration task, and independent read-only review.
-Subagents never promote previews, create snapshots, change workflow state, or
-install dependencies. The main agent performs the original stage transaction
-once after integration and review.
-
-## Stage 1: Generate the visual concept prototype
-
-1. Validate `prototype` resources.
-2. Read `prompts/01-generate-prototype.md` and generate `reports/content-map.json` only from `input/normalized-resume.json` and `input/approved-copy.json`. Use normalized facts as evidence and approved blocks as visible-copy input; do not silently rewrite them or use drafts and low-confidence inference.
-3. Before creating React source, run `scripts\portfolio_design_search.py recommend --input .resume-site-work\reports\content-map.json --output .resume-site-work\reports\design-intelligence.json`.
-4. Read `references/design-intelligence-contract.md` and `reports\design-intelligence.json`. Use `selected_direction_id` as soft design intent; never turn Catalog output into fixed JSX, HTML, a fixed component tree, or a page template.
-5. Read `references/creative-direction-contract.md`. From normalized facts, user-approved intent, and the design-intelligence candidates, compare two or three materially different creative layout families. Write `reports/creative-direction.json` with a fixed floor, open ceiling, and complete `concept_prototype`, then validate it before editing source:
+1. Set `stage=integrated_generating` and validate `integrated` resources.
+2. Read `prompts/01-generate-integrated-site.md`.
+3. Generate `reports/content-map.json` only from normalized facts and approved
+   copy. Create or refresh `reports/design-intelligence.json` as soft guidance.
+4. Translate the approved six decisions into implementation detail without
+   changing them. Create supporting media-direction, creative-direction, and
+   motion reports when applicable.
+5. Create or replace the complete source at `.resume-site-work/site` in one
+   integrated transaction. Apply structure, typography, color, media treatment,
+   one primary-motion system, and all selected compatible secondary effects.
+6. Validate and build:
 
 ```powershell
-python "$SKILL_ROOT\scripts\validate_creative_direction.py" ".resume-site-work\reports\creative-direction.json"
-```
-
-6. Create a genuine React + Vite project at `.resume-site-work\site`. Implement the `concept_prototype` now: establish its `visual_protagonist`, express the selected family through `composition_commitment`, apply the initial `type_color_character`, and render the `representative_interaction_state`. Follow the prompt's five-region composition, centralized content data, media fallbacks, approximately 1700px desktop width, and accessibility requirements.
-7. Run the `template_independence_test`: if removing final media and motion would leave a generic portfolio template, strengthen scale, rhythm, hierarchy, asymmetry, or the selected layout expression before presenting the prototype. Preserve every `creative_freedom.fixed` and `creative_freedom.avoid` entry while exploring the open ceiling. Reference-derived finishing, exact media treatment, and complex motion remains deferred.
-8. Validate as `prototype`, build, promote the successful preview, and snapshot to `.resume-site-work\versions\v1-prototype` (or the next retry suffix).
-9. Set `stage=prototype_waiting_confirmation`, show the built preview, and wait.
-
-### Prototype confirmation gate
-
-- On explicit confirmation, set `confirmations.prototype=true`, set `last_confirmed_artifact` to the candidate source snapshot, and advance to `media_direction_generating`.
-- On rejection, record feedback and the current ID in `attempted_direction_ids`; select the next unused candidate before re-querying, regenerate from normalized inputs, and create a new retry snapshot.
-- Do not enter media direction without confirmation.
-
-## Stage 2: Direct and apply the media art direction
-
-1. Read `references/design-intelligence-contract.md` and the current `reports\design-intelligence.json`. If the user provided a reference directory and `.resume-site-work\reference-library\manifest.json` is absent or stale, build it without touching the originals:
-
-```powershell
-python "$SKILL_ROOT\scripts\index_reference_library.py" `
-  "<reference-directory>" `
-  --workspace-root "."
-```
-
-2. When a reference-library manifest exists, inspect its `contact-sheets` with absolute Markdown image paths, then record selected source IDs and reasons in `reports/reference-selection.json`. Keep selected references at `usage_scope: "style_only"`; this evidence informs the internal media direction and never restores the old style confirmation gate.
-3. Read `references/reference-library-contract.md`, `references/style-brief-schema.md`, `references/creative-direction-contract.md`, `reports/creative-direction.json`, `references/media-art-direction-contract.md`, `references/media-art-direction-schema.json`, `prompts/02-analyze-reference.md`, and `prompts/03-direct-media-art.md`; read a generated workspace manifest only when references exist.
-4. Validate `media-direction` resources with `--workspace-root .`. A ready catalog does not substitute for unavailable media-direction resources.
-5. Prepare a StyleBrief internally when references exist; it is input to media direction, never a separate user gate. It may enrich the creative direction's open ceiling, but must not silently change its fixed floor or avoid rules. If the report changes, revalidate it before source edits. Keep references at `usage_scope: "style_only"`; do not publish them as site assets without separate authorization.
-6. Restore `.resume-site-work\versions\v1-prototype` into `.resume-site-work\site` when beginning or retrying this stage. Inspect the restored UI and authorized media, including each item's factual meaning and image role.
-7. Always create `reports\media-inventory.json` before writing the direction report. It must be the trusted, versioned inventory of authorized media; when no media is authorized, write the explicit empty inventory `{"schema_version": 1, "assets": []}`.
-8. Privately compare multiple media directions, exclude IDs in `attempted_media_direction_ids`, select exactly one winner, set `selected_media_direction_id`, and write `reports/media-art-direction.json` before editing source. Record structured `design_read`, `responsive_strategy`, and `reduced_motion_strategy` objects. Do not expose the internal comparison unless the user asks.
-9. Implement exactly that winner in the same React + Vite project. Preserve all confirmed content facts and never use generated assets as factual evidence.
-10. Validate `reports\media-art-direction.json` before validating the candidate as `media-direction`, then build it. Promote the preview only after all three succeed, so a failed attempt never replaces the last successful preview:
-
-```powershell
-python "$SKILL_ROOT\scripts\validate_media_art_direction.py" ".resume-site-work\reports\media-art-direction.json" --media-inventory ".resume-site-work\reports\media-inventory.json"
-python "$SKILL_ROOT\scripts\validate_vite_project.py" ".resume-site-work\site" --stage media-direction
+python "$SKILL_ROOT\scripts\validate_vite_project.py" `
+  ".resume-site-work\site" --stage integrated
 npm run build
 ```
-11. Snapshot the successful source to `.resume-site-work\versions\v2-media-direction` (or retry suffix), set `stage=media_direction_waiting_confirmation`, and show one interactive candidate.
 
-### Media direction confirmation gate
+7. On success, atomically promote `site/dist` to `preview/dist`, capture desktop,
+   tablet, mobile, representative interaction, coarse-pointer, and reduced-motion
+   states, and inspect console/layout/media safety.
+8. Perform at most two bounded local repair rounds. Do not silently change a
+   confirmed design decision. Keep the previous valid preview on failure.
+9. Snapshot successful source to `versions/v1-integrated` or a retry suffix,
+   set `stage=integrated_waiting_confirmation`, and show the complete website.
 
-- On explicit confirmation, set `confirmations.media_direction=true`, update `last_confirmed_artifact`, and advance to `screenshot_auditing`.
-- On rejection, restore `.resume-site-work\versions\v1-prototype`, record feedback and `selected_media_direction_id` in `attempted_media_direction_ids`, then return to `media_direction_generating` to implement one new winner.
-- Do not start automatic screenshot repair without confirmation.
+The first React candidate is one integrated website. Do not return to the old
+prototype, media-direction, and motion confirmation chain.
 
-## Stage 3: Audit screenshots and repair local defects
+## Final acceptance
 
-1. Validate `screenshot` resources, then read `references/screenshot-review-rules.md`, `prompts/04-audit-screenshot.md`, and `prompts/05-repair-local-issues.md`.
-2. Capture the successful built preview:
+Offer exactly three outcomes:
 
-```powershell
-python "$SKILL_ROOT\scripts\capture_site.py" ".resume-site-work\preview\dist\index.html" --output-dir ".resume-site-work\screenshots"
-```
+1. `当前效果满意，完成`
+2. `加强动效`
+3. `提出修改`
 
-3. On capture exit `2`, show its dependency commands and request approval before installation. Retry capture infrastructure once without consuming a visual repair round.
-4. Inspect desktop, tablet, and mobile screenshots plus `capture-report.json`; write schema-consistent findings to `reports/visual-audit.json`. Use the observable questions in `reports/creative-direction.json` to check whether the implementation preserves its fixed floor while expressing the selected creative thesis. Record `interaction_states_checked` evidence for the initial state and one representative active state per controller family, including each coarse-pointer/touch alternative and reduced-motion state. Exercise media loading, error, and Poster fallback states; check clipping, focus order, readability, image/UI cohesion, controller conflicts, and factual-media meaning.
-5. For blocking or repairable findings with `visual_repair_round < 2`, edit only affected React/CSS regions in `.resume-site-work\site`, increment the round, validate as `refined`, build, promote, and recapture all viewports.
-6. Preserve content, the confirmed media direction, and overall design direction. Do not rewrite the whole page for a local defect.
-7. When no blocking findings remain, snapshot `.resume-site-work\versions\v3-refined`, update state, and advance automatically to `motion_generating`.
-8. Treat essential-content loss, scroll traps, factual-media distortion, and absent fallbacks as blocking. After two completed repair rounds with blocking findings, set `stage=visual_blocked`, retain the last valid preview, and show unresolved defects. Do not present an incomplete page as complete.
+On `当前效果满意，完成`, set the integrated snapshot as
+`last_confirmed_artifact` and set `stage=complete`.
 
-Do not request routine confirmation during successful screenshot repair. This dynamic audit adds no confirmation step.
+On `加强动效`, restore the last valid integrated snapshot and change only the
+motion layer. Preserve content, structure, typography, color, and media
+treatment. Re-plan controller ownership, mobile/coarse-pointer behavior,
+cleanup, fallback, and reduced motion; validate/build/capture, snapshot a retry,
+then return to `integrated_waiting_confirmation`.
 
-## Stage 4: Production-harden the confirmed motion layer
+On `提出修改`, route bounded feedback to local repair. If feedback reverses a
+core decision, return to that decision category, invalidate its downstream
+decisions and approvals, reconfirm requirements, regenerate both plans, obtain
+new TODO plan approval, and generate a new integrated candidate.
 
-1. Validate `motion` resources, then read `references/motion-safety-rules.md`, `references/motion-production-contract.md`, and `prompts/06-add-motion.md`.
-2. Restore the refined snapshot when beginning or retrying motion. Consume the confirmed media direction, `reports/creative-direction.json`, refined audit, and inventory of installed effect sources, effects, controllers, and dependencies. Use `motion_freedom.purpose`, `allowed`, and `avoid` as the motion brief. Preserve the confirmed visual thesis; do not redesign it.
-3. Select only the sources the direction needs: CSS/native, React Bits, MotionSite, Motion, GSAP, and Three.js are available options, while React Bits is conditional. If React Bits is selected, register its official catalog and install exact `@react-bits` variants through the shadcn MCP.
-4. Write `reports/motion-plan.json` before editing source. There is no numeric effect cap: merge compatible controllers into shared timelines or isolate sections. Each item needs a unique ID plus source, target, purpose, controllers, dependencies, conflict_resolution, cleanup, mobile, reduced_motion, and fallback.
-5. Integrate only the planned source code in the same React + Vite project. Add lifecycle cleanup, coarse-pointer/mobile alternatives, static reduced-motion equivalents, and fallbacks. Do not restyle the page, rewrite resume content, or add runtime MCP dependence.
-6. Validate as `motion`, build, promote, recapture all viewports, inspect layout stability and console errors, and verify mobile/coarse-pointer, reduced-motion, and Poster/media safety.
-7. Snapshot `.resume-site-work\versions\v4-motion` (or retry suffix), set `stage=motion_waiting_confirmation`, show the animated preview and reduced-motion fallback, and wait.
+## Fast change
 
-### Motion confirmation gate
+A bounded existing-site edit requires a validated `workflow-route.json`, exact
+affected files, verification, a confirmed artifact, and rollback baseline. It
+must preserve approved facts, structure, visual thesis, and interaction
+architecture. If scope expands, stop and return to full discovery.
 
-- Offer exactly two completion choices: `当前动效足够，完成` and `继续加强动效`.
-- On `当前动效足够，完成`, set `confirmations.motion=true`, update `last_confirmed_artifact`, and set `stage=complete`.
-- On `继续加强动效`, keep the production-hardened v4 snapshot as the confirmed baseline and set `stage=motion_enhancement_selecting`. Load MotionSite resources only after their approved local catalog is available.
-- On rejection with specific motion feedback, restore `.resume-site-work\versions\v3-refined` (or the refined path recorded in state), revise only the motion plan/layer, and create a new retry snapshot.
+## Optional media and video paths
 
-## Stage 5: Add the optional recipe-based motion layer
+- APIHz search begins only on an explicit user request. Keep candidates local,
+  rights-unverified, and outside React until the user names IDs. Provider
+  failure leaves site, preview, approvals, snapshots, and state unchanged.
+- A later user-supplied local MP4/WebM may replace only an approved Poster/media
+  slot. Keep the Poster as loading, error, mobile-budget, and reduced-motion
+  fallback; validate/build/capture before promoting.
 
-1. Set `stage=motion_enhancement_selecting`. Validate `motion-enhancement` resources and read `references/motion-enhancement-contract.md`, `references/motion-recipe-schema.md`, `references/motion-media-slot-schema.md`, `references/video-embed-template.md`, and prompts 07–09.
-2. Read only `assets/motion-enhancement/catalog/manifest.json`, shortlist compatible candidates, and load only the candidate recipe JSON files. Select multiple compatible primary recipes and multiple secondary effects when needed; there is no numeric effect cap. Validate the selection with `validate_motion_plan.py selection`, rejecting unknown/duplicate IDs and unresolved target/controller ownership.
-3. Restore `.resume-site-work\versions\v4-motion`. Set `stage=motion_media_slot_planning`, preserve the confirmed page, and resolve the recipe placement reference into one site-specific media slot.
-4. When the slot supports media, set `stage=motion_poster_generating`. Prefer a user-supplied image; otherwise generate a decorative theme-consistent Poster. Store it below `.resume-site-work\media\posters`, write `reports/motion-media-slot.json`, and validate it with `validate_motion_media.py`.
-5. Poster generation is automatic when needed; user-supplied media is preferred. A user may request a replacement through ordinary feedback, which returns only to `motion_poster_generating`; it is not a confirmation state or a completion choice. Set `video_upgrade_available=true` after the Poster is retained.
-6. Set `stage=motion_enhancement_generating`. Apply the selected recipe through `prompts/09-apply-motion-enhancement.md`; change only the motion/media layer and keep video playback passive.
-7. Validate the project as `motion-enhanced`, run `npm run build`, capture desktop/tablet/mobile and reduced-motion states, and verify the Poster fallback.
-8. Snapshot `.resume-site-work\versions\v5-motion-enhanced-poster`, return to `stage=motion_waiting_confirmation`, and show the enhanced preview with its reduced-motion fallback. The existing motion confirmation choice remains the only completion decision.
-
-## Stage 6: Upgrade a confirmed Poster to video
-
-This stage is available later whenever `stage=complete`, `video_upgrade_available=true`, and the user supplies a local MP4/WebM.
-
-1. Set `stage=video_upgrade_validating`. Validate `video-upgrade` resources, read `references/video-upgrade-contract.md` and `prompts/10-upgrade-poster-to-video.md`, then run `validate_motion_media.py` against the confirmed Poster, supplied video, and media-slot report.
-2. If validation is blocked or fails, keep the Poster preview active and report the exact issue. Do not edit source.
-3. Restore `.resume-site-work\versions\v5-motion-enhanced-poster` and replace only the media component/assets. Keep the Poster as loading, error, mobile-budget, and reduced-motion fallback.
-4. Validate as `video-upgrade`, run `npm run build`, capture all viewports, and verify that video is local, muted, looping, inline, passive, and resilient to errors.
-5. On successful validation/build/capture, atomically promote the preview and snapshot `.resume-site-work\versions\v6-video-upgrade`, set `last_confirmed_video_artifact`, and return to `stage=complete` without another confirmation gate.
-6. On validation, build, or capture failure, keep or restore the confirmed Poster preview and return to `stage=complete`; do not regenerate the website or Poster.
-
-## Optional media search: APIHz images and GIFs
-
-This branch begins only after an `explicit user request` for a meme, reaction image, humorous image, or GIF. It is available between normal stages and never becomes a required `prototype`, `media-direction`, `screenshot`, or `motion` resource.
-
-1. Read `references/apihz-media-contract.md` and `prompts/11-search-optional-media.md`.
-2. Confirm that `APIHZ_ID` and `APIHZ_KEY` exist in the process environment without printing their values. Operators may configure additional exact CDN hosts through `APIHZ_ASSET_HOSTS`.
-3. Obtain a keyword of at most ten characters, or use random mode only when the user explicitly requests it. Run one search:
-
-```powershell
-python "$SKILL_ROOT\scripts\apihz_media.py" search --workspace-root "." --words "<keyword>" --limit 10
-python "$SKILL_ROOT\scripts\apihz_media.py" search --workspace-root "." --random --limit 10
-```
-
-4. Show the absolute local `.resume-site-work\media-search\<search-id>\preview.html` path. Explain that static images and animated GIF candidates are `rights-unverified`; do not edit the React project yet.
-5. Wait for explicit candidate IDs. Then run the selected-only import:
-
-```powershell
-python "$SKILL_ROOT\scripts\import_media_selection.py" --workspace-root "." --manifest ".resume-site-work\media-search\<search-id>\manifest.json" --select "media-a,media-b"
-```
-
-6. Use only imported `/assets/external/` paths in React, preserve GIF animation, and keep the selected site design direction. Never hotlink APIHz URLs or let a meme replace factual/user media.
-
-`provider-failure isolation`: missing credentials, rate limits, unsafe URLs, unsupported files, or network failures leave the current site, preview, confirmations, snapshots, and `build-state.json` unchanged. Report the stable category and keep the normal workflow available.
 ## Invariants
 
-- Persist `build-state.json` after every transition, successful candidate, rejection, and failure.
-- Update `last_confirmed_artifact` only after explicit confirmation.
-- Treat source validation, `npm run build`, and built-preview inspection as separate required checks.
-- Keep reference images out of published content unless the user authorizes their use beyond style analysis.
-- Preserve supplied facts and omit missing details instead of fabricating them.
-- Treat `reports/creative-direction.json` as the intent boundary: preserve its
-  fixed floor and avoid rules while keeping its open ceiling available for
-  genuine visual exploration.
-- Keep the main agent as integration owner for multi-agent work; shared files,
-  workflow state, preview promotion, and snapshots are never delegated.
+- Persist state after every transition, rejection, and failure.
+- Only conversation replies provide approval evidence.
+- Source validation, build, and built-preview inspection are separate checks.
+- Never publish reference-only media or fabricate facts, metrics, people, or
+  project images.
+- Preserve the last valid preview and immutable source snapshot on failure.
+- No external Superpowers skill is required at runtime.

--- a/skills/build-resume-portfolio-site/SKILL.md
+++ b/skills/build-resume-portfolio-site/SKILL.md
@@ -46,6 +46,11 @@ visual thesis, interaction architecture, or implementation strategy.
 
 1. Validate `discovery` resources.
 2. Inspect approved content, authorized media, references, and confirmed state.
+   When a reference library is present, build or refresh its catalog with
+   `scripts\index_reference_library.py --workspace-root .`, inspect the
+   generated `reference-library/contact-sheets`, record chosen evidence in
+   `reports/reference-selection.json`, respect `style_only` usage, and render
+   local evidence with absolute Markdown image paths.
 3. Ask one question at a time and complete these categories in exact order:
    overall structure, typography, color system, conditional media treatment,
    primary motion, and secondary motion.
@@ -114,13 +119,27 @@ integration, preview promotion, snapshots, and publication.
 1. Set `stage=integrated_generating` and validate `integrated` resources.
 2. Read `prompts/01-generate-integrated-site.md`.
 3. Generate `reports/content-map.json` only from normalized facts and approved
-   copy. Create or refresh `reports/design-intelligence.json` as soft guidance.
+   copy. Before React generation, run:
+
+```powershell
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" recommend `
+  --input ".resume-site-work\reports\content-map.json" `
+  --output ".resume-site-work\reports\design-intelligence.json"
+```
+
+   Treat `reports\design-intelligence.json` as soft guidance. Translate the
+   approved decisions into `reports/creative-direction.json` and validate it;
+   the report may add implementation detail but cannot reopen user choices.
 4. Translate the approved six decisions into implementation detail without
    changing them. Create supporting media-direction, creative-direction, and
    motion reports when applicable.
 5. Create or replace the complete source at `.resume-site-work/site` in one
    integrated transaction. Apply structure, typography, color, media treatment,
    one primary-motion system, and all selected compatible secondary effects.
+   Create the explicit empty or populated `reports/media-inventory.json`, pass
+   it with `--media-inventory` when media validation applies, and follow
+   `references/motion-production-contract.md`. Motion has no numeric effect cap;
+   compatibility and controller ownership are the limits.
 6. Validate and build:
 
 ```powershell
@@ -130,10 +149,12 @@ npm run build
 ```
 
 7. On success, atomically promote `site/dist` to `preview/dist`, capture desktop,
-   tablet, mobile, representative interaction, coarse-pointer, and reduced-motion
-   states, and inspect console/layout/media safety.
-8. Perform at most two bounded local repair rounds. Do not silently change a
-   confirmed design decision. Keep the previous valid preview on failure.
+   tablet, mobile, and `interaction_states_checked` evidence for initial and
+   representative active states. Inspect coarse-pointer/touch, reduced-motion,
+   loading, error, and Poster fallback behavior plus console/layout/media safety.
+8. Perform bounded local repair while `visual_repair_round < 2`. Do not request
+   routine confirmation during audit or silently change a confirmed design
+   decision. Keep the last valid preview on failure.
 9. Snapshot successful source to `versions/v1-integrated` or a retry suffix,
    set `stage=integrated_waiting_confirmation`, and show the complete website.
 
@@ -153,9 +174,11 @@ On `当前效果满意，完成`, set the integrated snapshot as
 
 On `加强动效`, restore the last valid integrated snapshot and change only the
 motion layer. Preserve content, structure, typography, color, and media
-treatment. Re-plan controller ownership, mobile/coarse-pointer behavior,
-cleanup, fallback, and reduced motion; validate/build/capture, snapshot a retry,
-then return to `integrated_waiting_confirmation`.
+treatment. Enter `motion_enhancing`, read
+`references/motion-production-contract.md`, and re-plan controller ownership,
+mobile/coarse-pointer behavior, cleanup, fallback, and reduced motion. Apply all
+compatible selected effects without a numeric effect cap, validate/build/capture,
+snapshot an integrated retry, then return to `integrated_waiting_confirmation`.
 
 On `提出修改`, route bounded feedback to local repair. If feedback reverses a
 core decision, return to that decision category, invalidate its downstream
@@ -171,12 +194,19 @@ architecture. If scope expands, stop and return to full discovery.
 
 ## Optional media and video paths
 
-- APIHz search begins only on an explicit user request. Keep candidates local,
-  rights-unverified, and outside React until the user names IDs. Provider
-  failure leaves site, preview, approvals, snapshots, and state unchanged.
+- The optional APIHz media transaction begins only on an explicit user request.
+  Require `APIHZ_ID` and `APIHZ_KEY`, then run
+  `python "$SKILL_ROOT\scripts\apihz_media.py" search` into
+  `.resume-site-work\media-search`. Show the local `preview.html`, including GIF
+  candidates, as rights-unverified evidence. Wait for candidate IDs, then use
+  `scripts\import_media_selection.py` for selected-only import. This is
+  provider-failure isolation: failure changes no site, preview, approval,
+  snapshot, or workflow state.
 - A later user-supplied local MP4/WebM may replace only an approved Poster/media
   slot. Keep the Poster as loading, error, mobile-budget, and reduced-motion
-  fallback; validate/build/capture before promoting.
+  fallback; validate/build/capture before atomically promoting. This is ordinary
+  feedback inside the existing final acceptance loop, never another confirmation
+  gate.
 
 ## Invariants
 

--- a/skills/build-resume-portfolio-site/agents/openai.yaml
+++ b/skills/build-resume-portfolio-site/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Resume Portfolio Site Builder"
-  short_description: "分阶段生成、检查并打磨可运行的简历与作品集单页网站"
+  short_description: "先确认六项设计与 TODO，再一次性生成可运行的简历作品集网站"
   default_prompt: "Use $build-resume-portfolio-site to create a runnable resume and portfolio website from my materials."

--- a/skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html
+++ b/skills/build-resume-portfolio-site/assets/visual-companion/gallery-shell.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Portfolio visual directions</title>
+  <title>Portfolio design decision preview</title>
   <style>
     :root {
       color-scheme: dark;
@@ -71,30 +71,29 @@
 </head>
 <body>
   <p class="notice">
-    Review these directions here, then approve in the conversation.
-    This page cannot record or grant approval.
+    Review these candidates here, then return to the conversation to confirm
+    or revise. This page cannot record or grant approval.
   </p>
   <main>
     <header>
-      <h1>Portfolio visual directions</h1>
+      <!-- preview-category -->
+      <h1>Replace with design category</h1>
       <p class="intro">
-        Compare composition, hierarchy, typography, color, density, responsive
-        behavior, and the representative interaction state.
+        Replace with the single visual question this independent preview answers.
       </p>
     </header>
     <div class="directions">
-      <!-- visual-directions -->
-      <article class="direction" data-direction-id="replace-direction-a">
+      <!-- visual-candidates -->
+      <article class="direction" data-candidate-id="replace-candidate-a">
         <div class="direction-meta">
-          <h2>Replace with direction title</h2>
+          <h2>Replace with candidate title</h2>
           <p>Replace with fit and trade-off summary</p>
         </div>
         <div class="canvas">
           Replace this canvas with a real-content visual mockup.
         </div>
         <p class="annotation">
-          Replace with the visual protagonist, composition commitment,
-          type/color character, responsive behavior, and interaction note.
+          Replace with category-specific evidence and relevant engineering notes.
         </p>
       </article>
     </div>

--- a/skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md
+++ b/skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md
@@ -1,0 +1,64 @@
+---
+resource_id: generate-integrated-site
+resource_version: 1
+resource_status: ready
+output_contract: react-vite-integrated-site
+---
+
+# Generate the integrated portfolio site
+
+Create one complete React + Vite portfolio at `.resume-site-work/site`. This is
+the first user-facing website candidate, not a structural prototype.
+
+## Required inputs
+
+Read and preserve:
+
+- `input/normalized-resume.json` as factual evidence;
+- `input/approved-copy.json` as visible-copy authority;
+- `reports/site-design-spec.json` schema version 3;
+- `reports/site-todo-plan.md` as the user-approved readable plan;
+- `reports/site-implementation-plan.json` schema version 2;
+- `reports/design-intelligence.json` as soft design guidance;
+- `reports/media-inventory.json` when authorized media exists.
+
+Do not implement when final requirements or TODO plan approval is missing.
+
+## Integrated implementation
+
+Apply all confirmed decisions in the same source transaction:
+
+- overall structure and content hierarchy;
+- typography roles, scale, rhythm, and reading texture;
+- color tokens, contrast, and semantic roles;
+- confirmed media treatment and local fallbacks, or the approved no-media path;
+- exactly one primary-motion system;
+- every selected compatible secondary effect.
+
+Keep resume content in a centralized data module. Use semantic sections for
+hero, experience, projects, strengths, and contact, but let the confirmed
+structure determine their composition rather than applying a generic template.
+Target an expressive desktop composition around 1700px while remaining usable
+at tablet and 390px mobile widths without horizontal overflow.
+
+## Engineering requirements
+
+- Use local, authorized media only; never fabricate factual project images.
+- Provide loading/error/static fallbacks for media and motion.
+- Provide visible focus, keyboard navigation, sufficient contrast, semantic
+  headings, and meaningful alternative text.
+- Resolve controller ownership across primary and secondary effects.
+- Provide coarse-pointer/mobile alternatives and a complete
+  `prefers-reduced-motion: reduce` presentation.
+- Clean up observers, listeners, animation frames, timelines, and WebGL state.
+- Keep `package.json` scripts for `dev` and `build`; do not switch frameworks,
+  use CDN React, or create a second standalone HTML site.
+
+## Output and verification
+
+Generate the complete source plus `reports/content-map.json`, motion planning
+evidence, and media-direction evidence when media is enabled. Then run the Skill
+project validator with `--stage integrated`, `npm run build`, and responsive
+screenshot capture. Repair only bounded observable defects, at most twice,
+without changing confirmed design decisions. Promote and snapshot only a
+successful integrated build.

--- a/skills/build-resume-portfolio-site/references/artifact-layout.md
+++ b/skills/build-resume-portfolio-site/references/artifact-layout.md
@@ -11,17 +11,15 @@ Create all generated material under `.resume-site-work/` in the active user work
 |-- site/                         # only editable React + Vite source project
 |-- style-preview/                # display-only discovery evidence
 |   |-- drafts/
-|   |   `-- <draft-id>/gallery.html
+|   |   `-- <category>/<draft-id>/gallery.html
 |   `-- sessions/
 |       `-- <session-id>/
 |           |-- gallery.html
 |           |-- assets/
 |           `-- state/server-info.json
 |-- versions/
-|   |-- v1-prototype/             # confirmed-source candidates; excludes dist/node_modules
-|   |-- v2-media-direction/
-|   |-- v3-refined/
-|   `-- v4-motion/
+|   |-- v1-integrated/            # first complete site; excludes dist/node_modules
+|   `-- v1-integrated-motion-rN/  # optional motion-only enhancement retries
 |-- preview/
 |   `-- dist/                     # latest successful npm run build output
 |-- screenshots/
@@ -31,6 +29,7 @@ Create all generated material under `.resume-site-work/` in the active user work
 |-- reports/
 |   |-- workflow-route.json
 |   |-- site-design-spec.json     # explicit product/experience approval
+|   |-- site-todo-plan.md         # readable plan shown and approved in conversation
 |   |-- site-implementation-plan.json # files, dependencies, checks, rollback
 |   |-- content-map.json
 |   |-- content-provenance.json
@@ -52,7 +51,8 @@ Create all generated material under `.resume-site-work/` in the active user work
 `style-preview/` contains display-only discovery evidence. Its galleries are
 not React source, production previews, confirmed snapshots, or publishable
 site output. Browser activity has no approval semantics; only an explicit
-conversation reply may be recorded in the version-2 site design specification.
+conversation reply may be recorded in the schema-version-3 site design
+specification. Category Galleries are independent rather than cumulative.
 Stopping a local session preserves its gallery for review.
 
 The three content files under `input/` plus
@@ -69,12 +69,14 @@ edit. It carries the creative thesis,
 review questions. It is not source code, a component tree, a new stage, or a
 confirmation artifact.
 
-`reports/site-design-spec.json` records the explicit website product and
-experience decision. `reports/site-implementation-plan.json` records exact
-files, task boundaries, interfaces, verification, rollback, and snapshot
-targets. Both validate before React source edits. The creative-direction report
-translates the approved design spec into an implementation-ready visual
-contract; it may not contradict it.
+`reports/site-design-spec.json` records all six category decisions and the
+final requirements approval. `reports/site-todo-plan.md` is the readable plan
+shown and explicitly approved in the conversation.
+`reports/site-implementation-plan.json` records that approval plus exact files,
+task boundaries, interfaces, verification, rollback, and the integrated
+snapshot target. All three gates complete before React source edits. The
+creative-direction report may translate the approved design spec into
+implementation detail but may not contradict it.
 
 `reports/multi-agent-implementation.json` exists only when the user explicitly
 authorizes multi-agent implementation. It records strategy, dependencies,

--- a/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
+++ b/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
@@ -1,31 +1,57 @@
 # Site Brainstorming Contract
 
 Use the full workflow for a new site or any change to audience, structure,
-visual thesis, layout family, interaction architecture, or implementation
-strategy.
+visual thesis, interaction architecture, or implementation strategy.
 
-1. Inspect the approved content package, authorized media, references,
-   existing site state, and confirmed artifacts.
-2. Ask one decision-bearing question at a time.
-3. Compare two or three materially different layout or experience families.
-4. Recommend one with explicit fit, risk, and responsive trade-offs.
-5. Define the visual protagonist, composition commitment, type/color
-   character, representative interaction, fixed constraints, open ceiling,
-   and avoid rules.
-6. Read `visual-style-preview-contract.md` and create one display-only
-   `gallery.html` that shows all two or three alternatives with approved
-   content. Keep it outside the React source project.
-7. Start the local companion when possible. Always provide the complete
-   authenticated URL and the standalone HTML fallback.
-8. Receive the candidate selection and explicit approval in the conversation.
-   Browser activity never counts as approval and never advances state.
-9. Write schema-version-2
-   `.resume-site-work/reports/site-design-spec.json`.
-10. Validate it before creating the implementation plan.
+## Required decision order
 
-Do not edit React source before the approved site design specification exists.
-Do not infer approval from a browser visit, screenshot, automatic launch, or
-silence.
+Inspect approved content, authorized media, references, existing state, and
+confirmed artifacts before asking questions. Ask one decision-bearing question
+at a time and complete these decisions in order:
+
+1. **Overall structure** — composition, hierarchy, navigation, and content density.
+2. **Typography** — type character, scale, rhythm, and reading texture.
+3. **Color system** — background, foreground, accent, contrast, and semantic roles.
+4. **Media treatment** — framing, cropping, sequencing, and fallback. Skip only
+   when no authorized media exists and the user does not want a media strategy;
+   record an explicit reason.
+5. **Primary motion** — select exactly one dominant temporal or scroll system.
+6. **Secondary motion** — allow multiple effects after filtering compatibility
+   with the primary system, controller ownership, performance, mobile,
+   coarse-pointer, cleanup, fallback, and reduced motion.
+7. **Final requirements confirmation** — summarize every enabled decision and
+   mandatory engineering constraint, then obtain explicit conversational approval.
+8. **TODO plan approval** — follow `site-planning-contract.md`; do not edit React
+   source until the readable plan is explicitly approved and the JSON plan validates.
+
+Responsive behavior, accessibility, coarse-pointer support, media fallbacks,
+and reduced motion are requirements, not optional style choices.
+
+## Per-category transaction
+
+For each enabled category:
+
+1. Compare two or three materially different candidates, except secondary
+   motion may offer more compatible effects without a fixed numeric cap.
+2. Recommend one candidate or compatible set and state fit, risk, and trade-offs.
+3. Receive a tentative selection in the conversation.
+4. Ask in a separate message whether to open the browser for this category.
+5. If accepted, follow `visual-style-preview-contract.md`; if declined, record
+   `not-requested` and continue text-only.
+6. Receive explicit confirmation, revision, or rejection in the conversation.
+7. Lock the decision before entering the next category.
+
+An accepted preview produces a display-only `gallery.html` outside the React
+source project.
+
+Prior browser consent does not apply to later categories. Browser activity never counts as approval and never advances state. Do not repeatedly offer a category after the user declines its preview.
+
+After final requirements confirmation, write schema-version-3
+`.resume-site-work/reports/site-design-spec.json` and validate it before
+planning. A changed core decision invalidates final requirements approval and
+all downstream planning artifacts.
+
+Do not create or edit React source during discovery or planning.
 
 Fast change is allowed only with a validated workflow route, a confirmed
 artifact, exact affected files, verification, and rollback baseline. If scope

--- a/skills/build-resume-portfolio-site/references/site-design-spec-schema.json
+++ b/skills/build-resume-portfolio-site/references/site-design-spec-schema.json
@@ -2,75 +2,187 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "SiteDesignSpec",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "schema_version",
     "spec_id",
     "workflow_mode",
     "content_revision",
-    "visual_protagonist",
-    "fixed_constraints",
-    "open_ceiling",
-    "avoid",
-    "alternatives",
-    "selected_alternative_id",
-    "composition_commitment",
-    "type_color_character",
-    "representative_interaction",
-    "approval"
+    "decision_order",
+    "decisions",
+    "engineering_constraints",
+    "requirements_approval"
   ],
   "properties": {
-    "schema_version": {"const": 2},
+    "schema_version": {"const": 3},
     "spec_id": {"type": "string", "minLength": 1},
     "workflow_mode": {"enum": ["full", "fast-change"]},
     "content_revision": {"type": "integer", "minimum": 1},
-    "visual_protagonist": {"type": "string", "minLength": 1},
-    "fixed_constraints": {"type": "array", "minItems": 1},
-    "open_ceiling": {"type": "array", "minItems": 1},
-    "avoid": {"type": "array", "minItems": 1},
-    "alternatives": {"type": "array", "minItems": 1, "maxItems": 3},
-    "selected_alternative_id": {"type": "string", "minLength": 1},
-    "composition_commitment": {"type": "string", "minLength": 1},
-    "type_color_character": {"type": "string", "minLength": 1},
-    "representative_interaction": {"type": "string", "minLength": 1},
-    "visual_preview": {
+    "decision_order": {
+      "const": [
+        "structure",
+        "typography",
+        "color",
+        "media",
+        "primary_motion",
+        "secondary_motion"
+      ]
+    },
+    "decisions": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
-        "mode",
-        "artifact",
-        "candidate_ids",
-        "recommended_candidate_id",
-        "selected_candidate_id",
-        "approval_channel",
-        "explicitly_approved"
+        "structure",
+        "typography",
+        "color",
+        "media",
+        "primary_motion",
+        "secondary_motion"
       ],
       "properties": {
-        "mode": {"const": "local-gallery"},
-        "artifact": {
-          "type": "string",
-          "pattern": "^\\.resume-site-work/style-preview/sessions/[^/]+/gallery\\.html$"
+        "structure": {"$ref": "#/$defs/singleDecision"},
+        "typography": {"$ref": "#/$defs/singleDecision"},
+        "color": {"$ref": "#/$defs/singleDecision"},
+        "media": {
+          "oneOf": [
+            {"$ref": "#/$defs/singleDecision"},
+            {"$ref": "#/$defs/skippedMedia"}
+          ]
         },
-        "candidate_ids": {
+        "primary_motion": {"$ref": "#/$defs/singleDecision"},
+        "secondary_motion": {"$ref": "#/$defs/multipleDecision"}
+      }
+    },
+    "engineering_constraints": {
+      "type": "array",
+      "minItems": 5,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1},
+      "allOf": [
+        {"contains": {"const": "responsive"}},
+        {"contains": {"const": "accessible"}},
+        {"contains": {"const": "coarse-pointer"}},
+        {"contains": {"const": "reduced-motion"}},
+        {"contains": {"const": "media-fallbacks"}}
+      ]
+    },
+    "requirements_approval": {"$ref": "#/$defs/approval"}
+  },
+  "$defs": {
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "tradeoffs"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "tradeoffs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "source", "channel"],
+      "properties": {
+        "status": {"const": "user_approved"},
+        "source": {"const": "explicit_user"},
+        "channel": {"const": "conversation"}
+      }
+    },
+    "preview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["offered", "response", "delivery", "artifact"],
+      "properties": {
+        "offered": {"const": true},
+        "response": {"enum": ["accepted", "declined"]},
+        "delivery": {
+          "enum": ["local-gallery", "static-fallback", "not-requested"]
+        },
+        "artifact": {
+          "type": ["string", "null"],
+          "pattern": "^\\.resume-site-work/style-preview/sessions/[^/]+/gallery\\.html$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"response": {"const": "declined"}}},
+          "then": {
+            "properties": {
+              "delivery": {"const": "not-requested"},
+              "artifact": {"type": "null"}
+            }
+          },
+          "else": {
+            "properties": {
+              "delivery": {"enum": ["local-gallery", "static-fallback"]},
+              "artifact": {"type": "string"}
+            }
+          }
+        }
+      ]
+    },
+    "decisionBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "candidates",
+        "recommended_candidate_id",
+        "tentative_selection_ids",
+        "selected_candidate_ids",
+        "preview",
+        "approval"
+      ],
+      "properties": {
+        "status": {"const": "confirmed"},
+        "candidates": {
           "type": "array",
           "minItems": 2,
-          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/candidate"}
+        },
+        "recommended_candidate_id": {"type": "string", "minLength": 1},
+        "tentative_selection_ids": {
+          "type": "array",
+          "minItems": 1,
           "uniqueItems": true,
           "items": {"type": "string", "minLength": 1}
         },
-        "recommended_candidate_id": {"type": "string", "minLength": 1},
-        "selected_candidate_id": {"type": "string", "minLength": 1},
-        "approval_channel": {"const": "conversation"},
-        "explicitly_approved": {"const": true}
+        "selected_candidate_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "preview": {"$ref": "#/$defs/preview"},
+        "approval": {"$ref": "#/$defs/approval"}
       }
     },
-    "approval": {"type": "object"}
-  },
-  "allOf": [
-    {
-      "if": {
-        "properties": {"workflow_mode": {"const": "full"}},
-        "required": ["workflow_mode"]
-      },
-      "then": {"required": ["visual_preview"]}
+    "singleDecision": {
+      "allOf": [
+        {"$ref": "#/$defs/decisionBase"},
+        {
+          "properties": {
+            "tentative_selection_ids": {"maxItems": 1},
+            "selected_candidate_ids": {"maxItems": 1}
+          }
+        }
+      ]
+    },
+    "multipleDecision": {"$ref": "#/$defs/decisionBase"},
+    "skippedMedia": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "skip_reason"],
+      "properties": {
+        "status": {"const": "skipped"},
+        "skip_reason": {"type": "string", "minLength": 1}
+      }
     }
-  ]
+  }
 }

--- a/skills/build-resume-portfolio-site/references/site-implementation-plan-schema.json
+++ b/skills/build-resume-portfolio-site/references/site-implementation-plan-schema.json
@@ -5,6 +5,9 @@
   "required": [
     "schema_version",
     "design_spec_id",
+    "todo_plan",
+    "todo_plan_approval",
+    "generation_mode",
     "strategy",
     "multi_agent_authorized",
     "multi_agent_plan",
@@ -13,13 +16,43 @@
     "snapshot_target"
   ],
   "properties": {
-    "schema_version": {"const": 1},
+    "schema_version": {"const": 2},
     "design_spec_id": {"type": "string", "minLength": 1},
+    "todo_plan": {
+      "const": ".resume-site-work/reports/site-todo-plan.md"
+    },
+    "todo_plan_approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "source", "channel"],
+      "properties": {
+        "status": {"const": "user_approved"},
+        "source": {"const": "explicit_user"},
+        "channel": {"const": "conversation"}
+      }
+    },
+    "generation_mode": {"const": "one-integrated-site"},
     "strategy": {
       "enum": ["single-agent", "fresh-agent-sequential", "parallel-wave"]
     },
     "multi_agent_authorized": {"type": "boolean"},
-    "tasks": {"type": "array", "minItems": 1},
+    "multi_agent_plan": {"type": ["string", "null"]},
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "depends_on",
+          "files",
+          "consumes",
+          "produces",
+          "acceptance",
+          "verification"
+        ]
+      }
+    },
     "rollback_baseline": {"type": "string", "minLength": 1},
     "snapshot_target": {"type": "string", "minLength": 1}
   }

--- a/skills/build-resume-portfolio-site/references/site-planning-contract.md
+++ b/skills/build-resume-portfolio-site/references/site-planning-contract.md
@@ -1,18 +1,38 @@
 # Site Planning Contract
 
-Create `.resume-site-work/reports/site-implementation-plan.json` only after the
-site design specification is explicitly approved.
+Begin only after schema-version-3 `site-design-spec.json` validates and its
+final requirements confirmation is explicitly approved.
 
-Each task records:
+## Readable TODO plan
 
-- stable task ID and dependencies;
-- exact writable files;
-- inputs consumed and interfaces produced;
-- acceptance criteria;
-- exact verification commands;
-- rollback and snapshot boundaries.
+Create `.resume-site-work/reports/site-todo-plan.md` first. It must be concise
+and readable in the conversation, with checkbox tasks covering:
+
+- content mapping and overall structure;
+- typography and color tokens;
+- authorized media treatment and fallbacks;
+- primary motion and every selected compatible secondary effect;
+- component and exact file boundaries;
+- responsive, accessibility, coarse-pointer, and reduced-motion behavior;
+- validation, build, screenshots, bounded repair, rollback, and delivery.
+
+Show the TODO plan, file scope, verification strategy, and expected artifacts.
+Wait for explicit conversational TODO plan approval. A browser action, silence,
+or approval of the design requirements is not plan approval.
+
+## Machine plan
+
+After approval, create schema-version-2
+`.resume-site-work/reports/site-implementation-plan.json`. It records the
+readable plan path and approval plus stable task IDs, dependencies, exact
+writable files, consumed inputs, produced interfaces, acceptance criteria,
+verification commands, rollback baseline, and `versions/v1-integrated`
+snapshot target. Set `generation_mode` to `one-integrated-site`.
 
 Select `single-agent`, `fresh-agent-sequential`, or `parallel-wave`.
-Multi-agent strategies require explicit user authorization and a separately
-validated `multi-agent-implementation.json`. Validate the site plan before any
-React source edit.
+Multi-agent strategies require explicit authorization and a separately
+validated `multi-agent-implementation.json`.
+
+Validate the JSON plan before any React source edit. If requirements change,
+invalidate both planning artifacts, regenerate them, show the new TODO plan,
+and obtain a new explicit approval.

--- a/skills/build-resume-portfolio-site/references/visual-style-preview-contract.md
+++ b/skills/build-resume-portfolio-site/references/visual-style-preview-contract.md
@@ -1,76 +1,78 @@
 # Visual Style Preview Contract
 
-Use this transaction during full site discovery after defining two or three
-materially different alternatives and before writing an approved site design
-specification.
+Use this display-only transaction after the user tentatively selects a
+candidate for one enabled discovery category. Ask separately for every enabled category. The six supported category IDs are `structure`, `typography`,
+`color`, `media`, `primary-motion`, and `secondary-motion`.
+
+Previews are independent, not cumulative. Each preview isolates its category
+against a neutral demonstration baseline. It is decision evidence, not reusable
+React source and not a fragment to concatenate into the final website.
+
+Declining one category does not suppress later preview offers. Record the
+decline as `response: declined`, `delivery: not-requested`, and `artifact: null`,
+then obtain the category confirmation in the conversation.
+
+## Offer
+
+After tentative selection, ask in a separate message whether the user wants to
+open a browser for this category. Do not create the Gallery or launch a browser
+before the user accepts. Consent applies only to the current category.
 
 ## Output
 
-Create one complete, standalone UTF-8 document at a new path:
+On acceptance, create one standalone UTF-8 document at:
 
 ```text
-.resume-site-work/style-preview/drafts/<draft-id>/gallery.html
+.resume-site-work/style-preview/drafts/<category>/<draft-id>/gallery.html
 ```
 
-Use `assets/visual-companion/gallery-shell.html` as structural guidance. The
-gallery contains:
+Use `assets/visual-companion/gallery-shell.html` as structural guidance. Show:
 
-- two or three directions with IDs matching `alternatives`;
+- the category name and question;
+- all candidates, with IDs matching the design-decision candidates;
+- a visual mark on the tentative selection that has no interaction semantics;
 - approved resume copy and only authorized local media;
-- visual protagonist, composition, typography, color, density, and hierarchy;
-- representative interaction state shown visually without executable control;
-- desktop framing and a compact/mobile frame when responsive behavior differs;
-- fit, risk, and responsive trade-offs for each direction;
-- a visible instruction to return to the conversation to select and approve.
+- the exact visual properties needed to judge this category;
+- relevant fit, risk, mobile, accessibility, fallback, and reduced-motion notes;
+- a visible instruction to return to the conversation to confirm or revise.
 
-The page is display-only. Do not add forms, buttons, `data-choice`, WebSockets,
-event collection, uploads, analytics, or approval controls. Browser activity
-never counts as selection or approval.
+Structure previews compare composition and hierarchy. Typography previews
+compare type and rhythm. Color previews compare color relationships. Media
+previews compare media treatment. Primary- and secondary-motion previews use
+small runnable samples, but contain no approval controls.
 
-Do not create or modify `.resume-site-work/site` while producing the gallery.
+The page is display-only. Do not add forms, buttons, `data-choice`, click or
+change handlers, WebSockets, event collection, uploads, analytics, or approval
+controls. Browser activity never counts as selection or approval.
+
+Do not create or modify `.resume-site-work/site` while producing a Gallery.
 
 ## Present
 
-Resolve `SKILL_ROOT` to this Skill directory, then run:
+Resolve `SKILL_ROOT`, then run only after the user accepted the current offer:
 
 ```powershell
 node "$SKILL_ROOT\scripts\visual_companion\launch.cjs" `
   --workspace-root "." `
-  --gallery ".resume-site-work\style-preview\drafts\<draft-id>\gallery.html" `
+  --gallery ".resume-site-work\style-preview\drafts\<category>\<draft-id>\gallery.html" `
   --open
 ```
 
-Read the single startup JSON object. Give the user both:
+Read the startup JSON. Give the user the complete authenticated `url` and the
+absolute `gallery.html` static fallback. Automatic-open failure is non-blocking.
+If Node, process lifetime, or loopback availability prevents the server, show
+the standalone HTML path. Never upload or publicly expose the Gallery.
 
-- the complete authenticated `url`, including its query string;
-- the absolute generated `gallery.html` path as the static fallback.
+## Confirm
 
-Automatic opening is best effort. `open_warning: "OPEN_FAILED"` leaves the
-server valid; show the URL. If Node is unavailable, launch fails, the process
-is reaped, or loopback is unreachable, show the standalone HTML path. In a
-remote environment, use only an existing user-authorized port-forwarding
-mechanism; do not publish or upload the gallery.
-
-Process lifetime differs by host. Keep `launch.cjs --foreground` alive through
-the host's asynchronous shell facility when detached processes are reaped.
-
-## Approve
-
-Ask the user to name a candidate in the conversation. After the reply:
-
-1. Record the chosen candidate in `selected_alternative_id` and
-   `visual_preview.selected_candidate_id`.
-2. Set `approval_channel` to `conversation`.
-3. Set `explicitly_approved` to `true` only after an explicit conversational
-   approval.
-4. Write schema-version-2 `reports/site-design-spec.json`.
-5. Validate it before writing the implementation plan.
-
-A browser visit, reload, screenshot, or system-browser launch is not approval.
+After display, ask the user to return to the conversation and confirm, revise,
+or reject. Record the decision-level `preview` and `approval` fields in the
+schema-version-3 design specification. A visit, reload, screenshot, or system
+browser launch is never approval.
 
 ## Stop
 
-Stop only the exact verified session from the returned `server_info`:
+Stop only the exact verified session returned by the launcher:
 
 ```powershell
 node "$SKILL_ROOT\scripts\visual_companion\stop.cjs" `
@@ -78,6 +80,4 @@ node "$SKILL_ROOT\scripts\visual_companion\stop.cjs" `
   --server-info "<returned-server-info-path>"
 ```
 
-Stopping preserves the session gallery. Draft and session artifacts are
-discovery evidence, not React source, confirmed snapshots, or publishable
-output.
+Stopping preserves the Gallery as discovery evidence.

--- a/skills/build-resume-portfolio-site/references/workflow-contract.md
+++ b/skills/build-resume-portfolio-site/references/workflow-contract.md
@@ -106,8 +106,11 @@ a validated bounded fast-change route. Schema-version-2 design reports remain
 readable evidence but do not satisfy new full discovery; schema-version-1 plans
 do not satisfy TODO plan approval. Never fabricate migrated approvals.
 
-## Optional side transactions
+## Optional APIHz media transaction
 
-APIHz search and later local-video upgrades do not change the discovery or
-planning gates. Provider or video failure restores the confirmed integrated
-artifact and leaves approvals unchanged.
+APIHz search and later local-video upgrades do not change the current portfolio
+stage, discovery or planning gates, approvals, or snapshot baseline. Candidate
+search remains outside the React project; selected-only import is explicit.
+Provider failure is isolated and the normal workflow remains available. Video
+failure restores the confirmed integrated artifact and leaves approvals
+unchanged.

--- a/skills/build-resume-portfolio-site/references/workflow-contract.md
+++ b/skills/build-resume-portfolio-site/references/workflow-contract.md
@@ -1,191 +1,113 @@
 # Workflow Contract
 
-## State machine
+Persist state after every transition. Never infer approval from silence,
+browser activity, or approval of another category.
 
-Persist state after every transition. Never infer approval from silence or from a previous stage.
-
-```text
-prototype_generating -> prototype_waiting_confirmation
-prototype_waiting_confirmation --confirm--> media_direction_generating
-prototype_waiting_confirmation --reject--> prototype_generating
-media_direction_generating -> media_direction_waiting_confirmation
-media_direction_waiting_confirmation --confirm--> screenshot_auditing
-media_direction_waiting_confirmation --reject--> media_direction_generating
-screenshot_auditing --clean--> motion_generating
-screenshot_auditing --repairable and rounds<2--> screenshot_repairing -> screenshot_auditing
-screenshot_auditing --blocking and rounds=2--> visual_blocked
-motion_generating -> motion_waiting_confirmation
-motion_waiting_confirmation --confirm current motion--> complete
-motion_waiting_confirmation --enhance--> motion_enhancement_selecting
-motion_waiting_confirmation --reject--> motion_generating
-```
-
-The optional motion continuation is an optional branch selected from the existing motion confirmation. Do not enter it without explicit user selection, and do not improvise MotionSite material when its approved local catalog is unavailable.
-
-The optional second layer and later video upgrade use these exact transitions:
+## Full workflow state machine
 
 ```text
-motion_enhancement_selecting -> motion_media_slot_planning
-motion_media_slot_planning --video-capable--> motion_poster_generating
-motion_media_slot_planning --no-media-needed--> motion_enhancement_generating
-motion_poster_generating -> motion_enhancement_generating
-motion_enhancement_generating -> motion_waiting_confirmation
-complete --video supplied and upgrade available--> video_upgrade_validating
-video_upgrade_validating --validate/build/promote--> complete
-video_upgrade_validating --failure--> complete with confirmed Poster restored
+content_preflight
+-> design_structure_selecting
+-> design_typography_selecting
+-> design_color_selecting
+-> design_media_selecting OR design_media_skipped
+-> design_primary_motion_selecting
+-> design_secondary_motion_selecting
+-> requirements_waiting_confirmation
+-> todo_plan_generating
+-> todo_plan_waiting_confirmation
+-> integrated_generating
+-> integrated_auditing
+-> integrated_waiting_confirmation
 ```
 
-## Content preflight transaction
+Every enabled design state contains tentative selection, a separate browser
+preview offer, optional independent Gallery presentation, and explicit
+conversational confirmation. A decline affects only that category.
 
-Content preflight runs before a new Stage 1 build and whenever a new resume,
-JD, factual claim, or copy revision enters scope. It is not a website stage or
-confirmation gate.
+`requirements_waiting_confirmation --confirm--> todo_plan_generating` writes
+the schema-v3 design specification. `todo_plan_waiting_confirmation --approve-->
+integrated_generating` is allowed only after the readable Markdown plan is shown
+and schema-v2 JSON plan validates.
 
-Validate the four-file content handoff. `CONTENT_READY` continues to Stage 1.
-`ROUTE_REQUIRED` invokes the **REQUIRED SUB-SKILL**
-`resume-content-intelligence`, waits for its user approval and handoff, then
-reruns validation. `CONTENT_INVALID` freezes website source, state, preview,
-and snapshots until the content Skill repairs or revises the package.
+## Integrated transaction
 
-Do not reroute when the request is to resume an existing confirmed site after
-prototype confirmation for visual, media, motion, responsive, accessibility,
-or frontend-only changes. In that path, preserve the confirmed content
-baseline.
+The integrated transaction is the first React generation:
 
-Stage 1 builds `content-map.json` only from the validated
-`normalized-resume.json` facts and `approved-copy.json` blocks. A new content
-revision must increase `handoff.revision`; the builder never overwrites or
-silently rewrites approved content.
+1. Restore the empty/new baseline or the last confirmed artifact for regeneration.
+2. Consume approved content, six decisions, readable TODO plan, JSON plan,
+   design intelligence, and authorized-media inventory.
+3. Edit only `.resume-site-work/site`.
+4. Apply structure, typography, color, media, primary motion, and compatible
+   secondary motion together.
+5. Validate with `--stage integrated`, run `npm run build`, then atomically
+   promote the successful `dist`.
+6. Capture desktop/tablet/mobile, interaction, coarse-pointer, and
+   reduced-motion states; inspect layout, console, accessibility, and fallbacks.
+7. Permit at most two bounded repair rounds.
+8. Snapshot successful source to `versions/v1-integrated` or a retry suffix.
 
-## Stage transaction
+A failed validation, build, or capture never replaces the last valid preview.
 
-Every generating or repair transition is one transaction:
-
-1. Restore the correct baseline snapshot when retrying.
-2. Edit the single React + Vite project at `.resume-site-work/site/`.
-3. Run `validate_vite_project.py` with the current stage.
-4. Run `npm run build` from `site/`.
-5. Replace `.resume-site-work/preview/dist/` with the successful `site/dist/` output.
-6. Save an immutable source snapshot for the new candidate.
-7. Capture and show `preview/dist/index.html`, then update state.
-
-If validation or build fails, keep the previous valid preview and confirmed snapshot active.
-
-## Discovery and planning transaction
-
-Before a new site or any structural, strategic, visual-direction,
-interaction-family, or implementation-strategy change:
+## Final acceptance state machine
 
 ```text
-inspect -> one question at a time -> compare 2-3 families ->
-site-design-spec approval -> site-implementation-plan validation -> implement
+integrated_waiting_confirmation --当前效果满意，完成--> complete
+integrated_waiting_confirmation --加强动效--> motion_enhancing
+motion_enhancing --validate/build/capture--> integrated_waiting_confirmation
+integrated_waiting_confirmation --提出修改 and bounded--> integrated_repairing
+integrated_repairing --validate/build/capture--> integrated_waiting_confirmation
+integrated_waiting_confirmation --提出修改 and core reversal--> affected design state
 ```
 
-The full workflow does not edit React source before explicit design approval
-and plan validation. `site-design-spec.json` is the user-approved product and
-experience decision. `creative-direction.json` is its implementation-ready
-visual translation.
+Motion enhancement preserves content, structure, typography, color, and media treatment. It may revise only primary/secondary motion plans and implementation.
+A core reversal invalidates that decision's downstream evidence, final
+requirements approval, TODO plan approval, and JSON implementation plan.
 
-An existing confirmed site may use `site-fast-change` only with a validated
-workflow route containing exact files, verification, and rollback baseline.
-Any expansion in facts, audience, structure, visual thesis, or interaction
-architecture returns to full discovery before further edits.
+## Content preflight
 
-## Multi-agent execution transaction
+Run content preflight before a new site and whenever a resume, JD, factual
+claim, or copy revision enters scope. `CONTENT_READY` continues;
+`ROUTE_REQUIRED` invokes `resume-content-intelligence` and waits for its approved
+handoff; `CONTENT_INVALID` freezes all website artifacts until repaired.
 
-Multi-agent work is an implementation strategy inside a generating or repair
-transaction. It never changes the state machine or adds a confirmation gate.
-Use it only after explicit user authorization and validate
-`reports/multi-agent-implementation.json` before dispatch.
+## Planning and strategy
 
-Choose one strategy:
+`site-design-spec.json` schema v3 is the user-approved requirements package.
+`site-todo-plan.md` is the readable plan explicitly approved in the
+conversation. `site-implementation-plan.json` schema v2 is the validated
+machine plan. All three precede React edits.
 
-- `single-agent` for local or tightly coupled edits;
-- `fresh-agent-sequential` for dependency chains that benefit from fresh
-  contexts;
-- `parallel-wave` only for independent tasks with disjoint write sets.
+Use `single-agent`, or an explicitly authorized and validated
+`fresh-agent-sequential`/`parallel-wave` plan. The main agent owns integration,
+shared files, state, preview promotion, snapshots, and publication.
 
-The main agent is the integration owner and retains workflow state, shared
-files, dependency decisions, preview promotion, snapshots, and publication.
-Parallel tasks have no overlapping file ownership. Tasks that need `App.jsx`,
-global CSS/tokens, central data, `package.json`, reports, state, preview, or
-versions hand those changes to the integration task instead of editing them
-concurrently.
+## Fast change
 
-At each wave boundary, inspect task reports and the working tree. After the
-integration task, run an independent specification review and quality audit;
-both are read-only. Route repairs to the original owner, with shared-file
-repairs kept by the integration owner. Only then execute the normal validation,
-build, capture, promotion, snapshot, and state-update transaction once.
+`site-fast-change` requires a confirmed artifact, exact files, verification,
+and rollback baseline. Any change to facts, audience, structure, visual thesis,
+or interaction architecture returns to full discovery.
 
-## Confirmation gates
+## Rollback and failure
 
-1. Show the built prototype preview and wait for explicit prototype confirmation.
-2. Show the built media-direction preview and wait for explicit media-direction confirmation.
-3. Show the built source-agnostic production-hardened motion preview and its reduced-motion behavior. Ask the user to choose either `当前动效足够，完成` or `继续加强动效`; enhancement returns to this same motion confirmation.
-
-Run screenshot audit and local repair without routine confirmation. Stop after two visual repair rounds if blocking defects remain.
-
-## Rollback
-
-- Retry a rejected prototype from the original normalized inputs and an empty/new `site/` project.
-- Retry rejected media direction by restoring `versions/v1-prototype` to `site/`, recording feedback and the selected ID in `attempted_media_direction_ids`, then implementing one new winner.
-- Retry screenshot repair by restoring the latest valid media-direction/refined candidate as appropriate.
-- Retry rejected motion by restoring `versions/v3-refined`, never from a partially animated project.
-- Replace an automatically generated or user-supplied Poster through ordinary feedback while retaining `versions/v4-motion` as the motion baseline.
-- Retry video upgrade from `versions/v5-motion-enhanced-poster` and edit only the media layer; a failed upgrade atomically keeps or restores the confirmed Poster preview.
-- Preserve every confirmed source snapshot and never overwrite version directories in place.
-
-## Failure states
-
-- Use `resource_blocked` when a required prompt, manifest, image, package dependency, browser dependency, shadcn MCP connection, or React Bits registry item is unavailable.
-- Use `artifact_invalid` when React/Vite source validation fails.
-- Use `build_failed` when `npm run build` fails; do not publish or capture stale `dist/` output.
-- Retry screenshot infrastructure once without incrementing `visual_repair_round`.
-- Use `visual_blocked` when two completed visual rounds leave blocking defects.
+- Preview failure falls back to the authenticated URL, static Gallery, or
+  text-only confirmation without affecting later offers.
+- Planning failure prevents source edits.
+- Integrated failure retains the previous valid preview and snapshot.
+- Motion enhancement starts from the last valid integrated snapshot.
+- Core-decision change invalidates only that decision and downstream artifacts.
+- `resource_blocked`, `artifact_invalid`, `build_failed`, and `visual_blocked`
+  retain exact diagnostics and never present stale output as current.
 
 ## State compatibility
 
-`build-state.json` has active schema version `4` and records `workflow_mode`
-plus the discovery flags `site_design_approved` and `site_plan_validated`.
-Version 3 has one explicit, one-way migration path through
-`scripts/migrate_build_state.py`; the source and output paths must differ, the
-output must not exist, and no prior confirmation may be changed. A valid
-confirmed version-3 snapshot migrates to `fast-change-eligible` while both new
-discovery flags remain false. This preserves completed work without fabricating
-historical approval. Systems reject every other old schema. Set
-`confirmations.media_direction` only after explicit user confirmation; its
-confirmation keys are `prototype`, `media_direction`, and `motion`. Do not
-create a separate confirmation for a StyleBrief.
+Build-state schema version `4` remains active. Older confirmed artifacts may use
+a validated bounded fast-change route. Schema-version-2 design reports remain
+readable evidence but do not satisfy new full discovery; schema-version-1 plans
+do not satisfy TODO plan approval. Never fabricate migrated approvals.
 
-## Design-intelligence and media-direction transaction
+## Optional side transactions
 
-Before `prototype_generating` edits React source, create `reports/design-intelligence.json` from `content-map.json`. Persist `selected_direction_id` and `attempted_direction_ids` in `build-state.json`. A rejected prototype selects an unused candidate before a new Catalog query.
-
-After design intelligence and before the first React source edit, create and
-validate `reports/creative-direction.json`. Its fixed floor contains approved
-facts, priorities, required behavior, and prohibitions; its open ceiling keeps
-composition, layout vocabulary, motion language, metaphor, and surface
-treatment available for exploration. It is not a new workflow stage or
-confirmation gate. A rejected prototype may move to another recorded layout
-candidate while preserving the fixed floor unless explicit user feedback
-changes it.
-
-Stage 1 must implement the report's `concept_prototype` as a visual concept
-prototype: one visual protagonist, a visible selected-layout commitment,
-initial type/color character, one representative interaction state, and a
-template-independence test. Reference-derived finishing, final media treatment,
-and complex motion remains deferred; core visual hierarchy does not.
-
-During `media_direction_generating`, prepare a visual StyleBrief internally when references exist. Reference evidence has priority over Catalog aesthetics. When no reference manifest exists, continue with the Catalog-only input path; absence is not a malformed resource. A present malformed manifest remains `resource_blocked`.
-
-Restore `versions/v1-prototype` before each media-direction attempt. Inspect the UI and authorized media, preserve the creative direction's fixed floor and avoid rules, and enrich only its open ceiling when reference evidence warrants it. Revalidate any changed creative-direction report. Always write the trusted `reports/media-inventory.json` (or `{"schema_version": 1, "assets": []}`), then write `reports/media-art-direction.json`, select one ID not present in `attempted_media_direction_ids`, implement that winner in the same React + Vite project, and validate/build it with `--media-inventory` before promotion. Snapshot only a successful candidate to `versions/v2-media-direction`; a failed attempt never replaces the last valid preview.
-## optional APIHz media transaction
-
-APIHz media search is an explicit, optional side transaction:
-
-```text
-explicit media request -> search -> local preview -> wait for candidate IDs -> selected-only import -> optional React placement
-```
-
-It does not change the current portfolio stage, confirmation flags, `last_confirmed_artifact`, active preview, or snapshot baseline. Search candidates remain below `media-search/`; only selected verified files are copied into the React project. Provider errors record no state transition, and the normal workflow remains available.
+APIHz search and later local-video upgrades do not change the discovery or
+planning gates. Provider or video failure restores the confirmed integrated
+artifact and leaves approvals unchanged.

--- a/skills/build-resume-portfolio-site/scripts/test_apihz_workflow.py
+++ b/skills/build-resume-portfolio-site/scripts/test_apihz_workflow.py
@@ -52,11 +52,12 @@ class APIHzWorkflowTests(unittest.TestCase):
         workflow = (SKILL_ROOT / "references" / "workflow-contract.md").read_text(
             encoding="utf-8"
         )
+        normalized_workflow = " ".join(workflow.split())
         self.assertIn("media-search/", artifact)
         self.assertIn("media-selection.json", artifact)
-        self.assertIn("optional APIHz media transaction", workflow)
-        self.assertIn("does not change the current portfolio stage", workflow)
-        self.assertIn("normal workflow remains available", workflow)
+        self.assertIn("Optional APIHz media transaction", workflow)
+        self.assertIn("do not change the current portfolio stage", normalized_workflow)
+        self.assertIn("normal workflow remains available", normalized_workflow)
         self.assertNotIn("<prototype|style|screenshot|motion|apihz>", skill_text())
 
 

--- a/skills/build-resume-portfolio-site/scripts/test_installed_apihz_media.py
+++ b/skills/build-resume-portfolio-site/scripts/test_installed_apihz_media.py
@@ -41,6 +41,8 @@ class MemoryResponse:
 
 class InstalledAPIHzMediaTests(unittest.TestCase):
     def test_plugin_metadata_advertises_optional_media(self) -> None:
+        if not PLUGIN_MANIFEST.is_file():
+            self.skipTest("repository plugin metadata is outside a standalone Skill install")
         manifest = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
         self.assertEqual(manifest["version"], "1.2.0")
         self.assertIn("optional-media", manifest["keywords"])

--- a/skills/build-resume-portfolio-site/scripts/test_installed_design_catalog.py
+++ b/skills/build-resume-portfolio-site/scripts/test_installed_design_catalog.py
@@ -15,6 +15,8 @@ PLUGIN_MANIFEST = REPOSITORY_ROOT / ".codex-plugin" / "plugin.json"
 
 class InstalledDesignCatalogTests(unittest.TestCase):
     def test_plugin_metadata_advertises_offline_design_intelligence(self) -> None:
+        if not PLUGIN_MANIFEST.is_file():
+            self.skipTest("repository plugin metadata is outside a standalone Skill install")
         manifest = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
         self.assertEqual(manifest["version"], "1.2.0")
         self.assertIn("design-intelligence", manifest["keywords"])

--- a/skills/build-resume-portfolio-site/scripts/test_installed_media_art_direction.py
+++ b/skills/build-resume-portfolio-site/scripts/test_installed_media_art_direction.py
@@ -47,6 +47,8 @@ def included_file_inventory(root: Path) -> dict[str, str]:
 
 class InstalledMediaArtDirectionTests(unittest.TestCase):
     def test_plugin_metadata_describes_the_internal_winner_workflow(self) -> None:
+        if not PLUGIN_MANIFEST.is_file():
+            self.skipTest("repository plugin metadata is outside a standalone Skill install")
         plugin = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
 
         self.assertEqual(plugin["version"], "1.2.0")

--- a/skills/build-resume-portfolio-site/scripts/test_installed_motion_enhancement_workflow.py
+++ b/skills/build-resume-portfolio-site/scripts/test_installed_motion_enhancement_workflow.py
@@ -8,21 +8,16 @@ SKILL_ROOT = Path(__file__).resolve().parents[1]
 
 
 class InstalledMotionEnhancementWorkflowTests(unittest.TestCase):
-    def test_optional_motion_and_video_continuations_add_no_confirmation_gate(self) -> None:
+    def test_motion_enhancement_and_video_stay_in_final_acceptance_loop(self) -> None:
         text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         required = (
-            "## Stage 5: Add the optional recipe-based motion layer",
-            "motion_enhancement_selecting",
-            "motion_poster_generating",
-            "ordinary feedback",
-            "motion_enhancement_generating",
-            "motion_waiting_confirmation",
-            "video_upgrade_available",
-            "versions\\v5-motion-enhanced-poster",
-            "## Stage 6: Upgrade a confirmed Poster to video",
-            "video_upgrade_validating",
+            "On `加强动效`",
+            "motion_enhancing",
+            "ordinary\n  feedback",
+            "integrated_waiting_confirmation",
+            "user-supplied local MP4/WebM",
             "atomically",
-            "versions\\v6-video-upgrade",
+            "never another confirmation\n  gate",
         )
         for marker in required:
             with self.subTest(marker=marker):

--- a/skills/build-resume-portfolio-site/scripts/test_installed_motion_workflow.py
+++ b/skills/build-resume-portfolio-site/scripts/test_installed_motion_workflow.py
@@ -47,10 +47,10 @@ class InstalledMotionWorkflowTests(unittest.TestCase):
         text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         required = (
             "references/motion-production-contract.md",
-            "confirmed media direction",
-            "refined audit",
-            "no numeric effect cap",
-            "motion_enhancement_selecting",
+            "primary-motion system",
+            "compatible secondary effects",
+            "numeric effect cap",
+            "motion_enhancing",
         )
         for marker in required:
             with self.subTest(marker=marker):

--- a/skills/build-resume-portfolio-site/scripts/test_installed_skill_workflow.py
+++ b/skills/build-resume-portfolio-site/scripts/test_installed_skill_workflow.py
@@ -10,20 +10,16 @@ ARTIFACT_LAYOUT_PATH = SKILL_ROOT / "references" / "artifact-layout.md"
 
 
 class InstalledSkillWorkflowTests(unittest.TestCase):
-    def test_workflow_uses_one_react_vite_project(self) -> None:
+    def test_workflow_uses_one_integrated_react_vite_project(self) -> None:
         text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         required = (
             "React + Vite",
             "references/react-vite-output-contract.md",
             "scripts\\validate_vite_project.py",
-            "scripts\\snapshot_vite_project.py",
             ".resume-site-work\\site",
             "npm run build",
-            ".resume-site-work\\preview\\dist\\index.html",
-            "versions\\v1-prototype",
-            "versions\\v2-media-direction",
-            "versions\\v3-refined",
-            "versions\\v4-motion",
+            "versions/v1-integrated",
+            "one integrated website",
         )
         for marker in required:
             with self.subTest(marker=marker):
@@ -32,67 +28,48 @@ class InstalledSkillWorkflowTests(unittest.TestCase):
         self.assertNotIn("validate_site.py", text)
         self.assertNotIn("site-v1-prototype.html", text)
 
-    def test_workflow_preserves_all_three_confirmation_gates(self) -> None:
+    def test_workflow_replaces_staged_confirmation_with_upfront_approval(self) -> None:
         text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
-        for heading in (
+        for marker in (
+            "schema-version-3",
+            "site-todo-plan.md",
+            "explicit TODO plan approval",
+            "one integrated website",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, text)
+        for retired in (
             "### Prototype confirmation gate",
             "### Media direction confirmation gate",
             "### Motion confirmation gate",
         ):
-            with self.subTest(heading=heading):
-                self.assertIn(heading, text)
-        self.assertNotIn("### Style confirmation gate", text)
-        self.assertEqual(
-            [
-                line
-                for line in text.splitlines()
-                if line.startswith("### ") and line.endswith("confirmation gate")
-            ],
-            [
-                "### Prototype confirmation gate",
-                "### Media direction confirmation gate",
-                "### Motion confirmation gate",
-            ],
-        )
+            self.assertNotIn(retired, text)
 
-    def test_workflow_replaces_style_state_with_media_direction_state(self) -> None:
+    def test_workflow_records_all_six_decisions_before_generation(self) -> None:
         text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         for marker in (
-            "media_direction_generating",
-            "media_direction_waiting_confirmation",
-            "confirmations.media_direction",
-            "selected_media_direction_id",
-            "attempted_media_direction_ids",
-            "versions\\v2-media-direction",
-            "reports/media-art-direction.json",
+            "overall structure",
+            "typography",
+            "color system",
+            "conditional media treatment",
+            "primary motion",
+            "secondary motion",
+            "independent display-only",
         ):
             with self.subTest(marker=marker):
                 self.assertIn(marker, text)
-        self.assertNotIn("style_waiting_confirmation", text)
+        self.assertNotIn("media_direction_waiting_confirmation", text)
 
-    def test_optional_motion_continuation_uses_only_the_motion_confirmation(self) -> None:
+    def test_final_acceptance_has_exactly_three_outcomes(self) -> None:
         skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         layout = ARTIFACT_LAYOUT_PATH.read_text(encoding="utf-8")
         combined = skill + workflow + layout
 
-        self.assertIn(
-            "motion_waiting_confirmation --enhance--> motion_enhancement_selecting",
-            workflow,
-        )
-        self.assertIn(
-            "motion_enhancement_generating -> motion_waiting_confirmation",
-            workflow,
-        )
-        self.assertIn('"confirmations": {"prototype": false, "media_direction": false, "motion": false}', combined)
-        for retired in (
-            "motion_poster_waiting_confirmation",
-            "motion_enhancement_waiting_confirmation",
-            "video_upgrade_waiting_confirmation",
-            "confirmations.motion_enhancement",
-        ):
-            with self.subTest(retired=retired):
-                self.assertNotIn(retired, combined)
+        for outcome in ("当前效果满意，完成", "加强动效", "提出修改"):
+            self.assertIn(outcome, combined)
+        self.assertIn("motion_enhancing", workflow)
+        self.assertNotIn("motion_waiting_confirmation", workflow)
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/test_media_art_direction_workflow.py
+++ b/skills/build-resume-portfolio-site/scripts/test_media_art_direction_workflow.py
@@ -162,36 +162,31 @@ class MediaArtDirectionWorkflowTests(unittest.TestCase):
             .issubset(invalid_controller)
         )
 
-    def test_workflow_persists_the_media_direction_gate_and_artifacts(self):
+    def test_workflow_integrates_media_direction_without_a_late_gate(self):
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         layout = ARTIFACT_LAYOUT_PATH.read_text(encoding="utf-8")
 
         for marker in (
-            "prototype_waiting_confirmation --confirm--> media_direction_generating",
-            "media_direction_generating -> media_direction_waiting_confirmation",
-            "media_direction_waiting_confirmation --confirm--> screenshot_auditing",
-            "media_direction_waiting_confirmation --reject--> media_direction_generating",
-            "confirmations.media_direction",
-            "selected_media_direction_id",
-            "attempted_media_direction_ids",
-            "versions/v2-media-direction",
-            "reports/media-art-direction.json",
+            "design_media_selecting OR design_media_skipped",
+            "integrated_generating",
+            "versions/v1-integrated",
+            "media-art-direction.json",
             "reports/media-inventory.json",
             '"schema_version": 4',
-            "reject every other old schema",
+            "Never fabricate migrated approvals",
         ):
             with self.subTest(marker=marker):
                 self.assertIn(marker, workflow + layout)
 
-        self.assertNotIn("style_waiting_confirmation", workflow + layout)
-        self.assertNotIn("v2-styled", workflow + layout)
+        self.assertNotIn("media_direction_waiting_confirmation", workflow + layout)
+        self.assertNotIn("versions/v2-media-direction", workflow + layout)
 
     def test_optional_motion_enhancement_is_not_a_fourth_gate(self):
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
 
-        self.assertIn("## Confirmation gates", workflow)
-        self.assertIn("optional branch", workflow)
-        self.assertNotIn("a deliberate gate", workflow)
+        self.assertIn("## Final acceptance state machine", workflow)
+        self.assertIn("--加强动效--> motion_enhancing", workflow)
+        self.assertNotIn("motion_enhancement_waiting_confirmation", workflow)
 
     def test_prompt_and_skill_require_an_explicit_empty_or_populated_inventory(self):
         prompt = PROMPT_PATH.read_text(encoding="utf-8")

--- a/skills/build-resume-portfolio-site/scripts/test_media_visual_audit_workflow.py
+++ b/skills/build-resume-portfolio-site/scripts/test_media_visual_audit_workflow.py
@@ -60,10 +60,10 @@ class MediaVisualAuditWorkflowTests(unittest.TestCase):
             "loading, error, and Poster fallback",
             "last valid preview",
             "visual_repair_round < 2",
-            "Do not request routine confirmation",
+            "do not request\n   routine confirmation",
         ):
             with self.subTest(marker=marker):
-                self.assertIn(marker, skill)
+                self.assertIn(marker.lower(), skill.lower())
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/test_synced_workflow_baseline.py
+++ b/skills/build-resume-portfolio-site/scripts/test_synced_workflow_baseline.py
@@ -27,6 +27,18 @@ class SyncedWorkflowBaselineTests(unittest.TestCase):
         self.assertIn("parallel-wave", text)
         self.assertIn("creative-direction.json", text)
 
+    def test_skill_uses_upfront_design_and_todo_approval(self) -> None:
+        text = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+        for marker in (
+            "schema-version-3",
+            "site-todo-plan.md",
+            "one integrated website",
+            "当前效果满意，完成",
+            "加强动效",
+            "提出修改",
+        ):
+            self.assertIn(marker, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py
+++ b/skills/build-resume-portfolio-site/scripts/test_validate_site_design_spec.py
@@ -12,46 +12,92 @@ ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = ROOT / "scripts" / "validate_site_design_spec.py"
 
 
-def valid_spec() -> dict:
+def _candidates(prefix: str, count: int = 2) -> list[dict[str, object]]:
+    return [
+        {
+            "id": f"{prefix}-{index}",
+            "label": f"{prefix.title()} {index}",
+            "tradeoffs": [f"{prefix} tradeoff {index}"],
+        }
+        for index in range(1, count + 1)
+    ]
+
+
+def confirmed_decision(
+    category: str,
+    *,
+    selected: list[str] | None = None,
+    response: str = "accepted",
+) -> dict[str, object]:
+    candidates = _candidates(category, 3 if category == "secondary-motion" else 2)
+    selected_ids = selected or [str(candidates[0]["id"])]
+    preview = {
+        "offered": True,
+        "response": response,
+        "delivery": "local-gallery" if response == "accepted" else "not-requested",
+        "artifact": (
+            f".resume-site-work/style-preview/sessions/{category}-1/gallery.html"
+            if response == "accepted"
+            else None
+        ),
+    }
     return {
-        "schema_version": 2,
+        "status": "confirmed",
+        "candidates": candidates,
+        "recommended_candidate_id": candidates[0]["id"],
+        "tentative_selection_ids": [candidates[0]["id"]],
+        "selected_candidate_ids": selected_ids,
+        "preview": preview,
+        "approval": {
+            "status": "user_approved",
+            "source": "explicit_user",
+            "channel": "conversation",
+        },
+    }
+
+
+def valid_spec() -> dict[str, object]:
+    secondary = confirmed_decision("secondary-motion")
+    secondary["selected_candidate_ids"] = [
+        secondary["candidates"][0]["id"],
+        secondary["candidates"][1]["id"],
+    ]
+    return {
+        "schema_version": 3,
         "spec_id": "site-spec-1",
         "workflow_mode": "full",
         "content_revision": 1,
-        "visual_protagonist": "project outcomes",
-        "fixed_constraints": ["preserve approved copy"],
-        "open_ceiling": ["composition", "motion language"],
-        "avoid": ["generic card grid"],
-        "alternatives": [
-            {
-                "id": "editorial",
-                "family": "radical editorial",
-                "tradeoffs": ["denser reading rhythm"],
-            },
-            {
-                "id": "cinematic",
-                "family": "cinematic portfolio",
-                "tradeoffs": ["higher media dependency"],
-            },
+        "decision_order": [
+            "structure",
+            "typography",
+            "color",
+            "media",
+            "primary_motion",
+            "secondary_motion",
         ],
-        "selected_alternative_id": "editorial",
-        "composition_commitment": "asymmetric editorial stage",
-        "type_color_character": "high-contrast serif and restrained yellow",
-        "representative_interaction": (
-            "project selection updates one detail panel"
-        ),
-        "visual_preview": {
-            "mode": "local-gallery",
-            "artifact": (
-                ".resume-site-work/style-preview/sessions/style-1/gallery.html"
-            ),
-            "candidate_ids": ["editorial", "cinematic"],
-            "recommended_candidate_id": "editorial",
-            "selected_candidate_id": "editorial",
-            "approval_channel": "conversation",
-            "explicitly_approved": True,
+        "decisions": {
+            "structure": confirmed_decision("structure"),
+            "typography": confirmed_decision("typography"),
+            "color": confirmed_decision("color"),
+            "media": {
+                "status": "skipped",
+                "skip_reason": "no authorized media",
+            },
+            "primary_motion": confirmed_decision("primary-motion"),
+            "secondary_motion": secondary,
         },
-        "approval": {"status": "user_approved", "source": "explicit_user"},
+        "engineering_constraints": [
+            "responsive",
+            "accessible",
+            "coarse-pointer",
+            "reduced-motion",
+            "media-fallbacks",
+        ],
+        "requirements_approval": {
+            "status": "user_approved",
+            "source": "explicit_user",
+            "channel": "conversation",
+        },
     }
 
 
@@ -70,49 +116,100 @@ class SiteDesignSpecValidatorTests(unittest.TestCase):
     def test_accepts_valid_full_spec(self) -> None:
         self.assertEqual(self.run_validator(valid_spec()).returncode, 0)
 
-    def test_rejects_one_full_mode_alternative(self) -> None:
+    def test_rejects_wrong_decision_order(self) -> None:
         payload = valid_spec()
-        payload["alternatives"] = payload["alternatives"][:1]
-        self.assertEqual(self.run_validator(payload).returncode, 1)
-
-    def test_rejects_duplicate_layout_families(self) -> None:
-        payload = valid_spec()
-        payload["alternatives"][1]["family"] = "radical editorial"
-        self.assertEqual(self.run_validator(payload).returncode, 1)
-
-    def test_rejects_fixed_and_avoid_overlap(self) -> None:
-        payload = valid_spec()
-        payload["avoid"] = ["preserve approved copy"]
-        self.assertEqual(self.run_validator(payload).returncode, 1)
-
-    def test_rejects_missing_explicit_approval(self) -> None:
-        payload = valid_spec()
-        payload["approval"]["source"] = "inferred"
-        self.assertEqual(self.run_validator(payload).returncode, 1)
-
-    def test_rejects_missing_visual_preview(self) -> None:
-        payload = valid_spec()
-        payload.pop("visual_preview")
+        payload["decision_order"][0:2] = ["typography", "structure"]
         result = self.run_validator(payload)
         self.assertEqual(result.returncode, 1)
-        self.assertIn("full mode requires visual_preview", result.stdout)
+        self.assertIn("decision_order", result.stdout)
 
-    def test_rejects_browser_approval_channel(self) -> None:
+    def test_rejects_missing_preview_offer_for_enabled_category(self) -> None:
         payload = valid_spec()
-        payload["visual_preview"]["approval_channel"] = "browser"
+        payload["decisions"]["color"]["preview"]["offered"] = False
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("color preview must be offered", result.stdout)
+
+    def test_accepts_declined_preview_and_later_accepted_preview(self) -> None:
+        payload = valid_spec()
+        payload["decisions"]["structure"]["preview"] = {
+            "offered": True,
+            "response": "declined",
+            "delivery": "not-requested",
+            "artifact": None,
+        }
+        self.assertEqual(self.run_validator(payload).returncode, 0)
+        self.assertEqual(
+            payload["decisions"]["typography"]["preview"]["response"],
+            "accepted",
+        )
+
+    def test_rejects_media_skip_without_reason(self) -> None:
+        payload = valid_spec()
+        payload["decisions"]["media"].pop("skip_reason")
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("media skip requires a reason", result.stdout)
+
+    def test_rejects_multiple_primary_motion_selections(self) -> None:
+        payload = valid_spec()
+        decision = payload["decisions"]["primary_motion"]
+        decision["selected_candidate_ids"] = [
+            decision["candidates"][0]["id"],
+            decision["candidates"][1]["id"],
+        ]
         result = self.run_validator(payload)
         self.assertEqual(result.returncode, 1)
         self.assertIn(
-            "visual_preview approval_channel must be conversation",
+            "primary_motion requires exactly one selected candidate",
             result.stdout,
         )
 
-    def test_rejects_version_one(self) -> None:
+    def test_accepts_multiple_compatible_secondary_motion_selections(self) -> None:
         payload = valid_spec()
-        payload["schema_version"] = 1
+        decision = payload["decisions"]["secondary_motion"]
+        decision["selected_candidate_ids"] = [
+            candidate["id"] for candidate in decision["candidates"]
+        ]
+        self.assertEqual(self.run_validator(payload).returncode, 0)
+
+    def test_rejects_unknown_secondary_motion_selection(self) -> None:
+        payload = valid_spec()
+        payload["decisions"]["secondary_motion"][
+            "selected_candidate_ids"
+        ] = ["unknown-effect"]
+        self.assertEqual(self.run_validator(payload).returncode, 1)
+
+    def test_rejects_unapproved_final_requirements(self) -> None:
+        payload = valid_spec()
+        payload["requirements_approval"]["status"] = "pending"
         result = self.run_validator(payload)
         self.assertEqual(result.returncode, 1)
-        self.assertIn("schema_version must be 2", result.stdout)
+        self.assertIn("final requirements require user approval", result.stdout)
+
+    def test_rejects_browser_approval_channel(self) -> None:
+        payload = valid_spec()
+        payload["decisions"]["typography"]["approval"]["channel"] = "browser"
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "typography approval must be explicit and conversational",
+            result.stdout,
+        )
+
+    def test_rejects_accepted_preview_without_session_gallery(self) -> None:
+        payload = valid_spec()
+        payload["decisions"]["structure"]["preview"]["artifact"] = (
+            "../gallery.html"
+        )
+        self.assertEqual(self.run_validator(payload).returncode, 1)
+
+    def test_rejects_version_two_for_new_full_discovery(self) -> None:
+        payload = valid_spec()
+        payload["schema_version"] = 2
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("schema_version must be 3", result.stdout)
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/test_validate_site_implementation_plan.py
+++ b/skills/build-resume-portfolio-site/scripts/test_validate_site_implementation_plan.py
@@ -14,33 +14,40 @@ VALIDATOR = ROOT / "scripts" / "validate_site_implementation_plan.py"
 
 def valid_plan() -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "design_spec_id": "site-spec-1",
+        "todo_plan": ".resume-site-work/reports/site-todo-plan.md",
+        "todo_plan_approval": {
+            "status": "user_approved",
+            "source": "explicit_user",
+            "channel": "conversation",
+        },
+        "generation_mode": "one-integrated-site",
         "strategy": "single-agent",
         "multi_agent_authorized": False,
         "multi_agent_plan": None,
         "tasks": [
             {
-                "id": "prototype-shell",
+                "id": "integrated-site",
                 "depends_on": [],
                 "files": ["src/App.jsx", "src/styles.css"],
                 "consumes": [
                     "approved-copy.json",
                     "site-design-spec.json",
                 ],
-                "produces": ["five-region prototype"],
+                "produces": ["complete integrated portfolio"],
                 "acceptance": [
                     "Representative interaction is rendered."
                 ],
                 "verification": [
                     "python validate_vite_project.py "
-                    ".resume-site-work/site --stage prototype",
+                    ".resume-site-work/site --stage integrated",
                     "npm run build",
                 ],
             }
         ],
         "rollback_baseline": "empty/new site",
-        "snapshot_target": "versions/v1-prototype",
+        "snapshot_target": "versions/v1-integrated",
     }
 
 
@@ -88,6 +95,49 @@ class SiteImplementationPlanValidatorTests(unittest.TestCase):
         duplicate["id"] = "duplicate-owner"
         payload["tasks"].append(duplicate)
         self.assertEqual(self.run_validator(payload).returncode, 1)
+
+    def test_rejects_missing_readable_todo_plan_path(self) -> None:
+        payload = valid_plan()
+        payload.pop("todo_plan")
+        self.assertEqual(self.run_validator(payload).returncode, 1)
+
+    def test_rejects_todo_plan_outside_reports(self) -> None:
+        payload = valid_plan()
+        payload["todo_plan"] = "docs/site-todo-plan.md"
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("todo_plan must reference", result.stdout)
+
+    def test_rejects_unapproved_todo_plan(self) -> None:
+        payload = valid_plan()
+        payload["todo_plan_approval"]["status"] = "pending"
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("todo plan requires user approval", result.stdout)
+
+    def test_rejects_browser_todo_plan_approval(self) -> None:
+        payload = valid_plan()
+        payload["todo_plan_approval"]["channel"] = "browser"
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "todo plan approval must be explicit and conversational",
+            result.stdout,
+        )
+
+    def test_rejects_non_integrated_generation_mode(self) -> None:
+        payload = valid_plan()
+        payload["generation_mode"] = "prototype-first"
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("generation_mode must be one-integrated-site", result.stdout)
+
+    def test_rejects_version_one(self) -> None:
+        payload = valid_plan()
+        payload["schema_version"] = 1
+        result = self.run_validator(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("schema_version must be 2", result.stdout)
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/test_validate_skill_resources.py
@@ -14,6 +14,10 @@ from validate_skill_resources import validate_resources
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 PROMPTS = {
+    "generate-integrated-site": (
+        "01-generate-integrated-site.md",
+        "react-vite-integrated-site",
+    ),
     "generate-prototype": ("01-generate-prototype.md", "react-vite-project"),
     "analyze-reference": ("02-analyze-reference.md", "style-brief-json"),
     "direct-media-art": (
@@ -194,6 +198,11 @@ class ValidateSkillResourcesTests(unittest.TestCase):
 
     def test_runtime_accepts_planning_contracts(self) -> None:
         report = validate_resources(SKILL_ROOT, "runtime", "planning")
+        self.assertTrue(report.ok, report.errors)
+        self.assertTrue(report.ready, report.errors)
+
+    def test_runtime_accepts_integrated_generation_resources(self) -> None:
+        report = validate_resources(SKILL_ROOT, "runtime", "integrated")
         self.assertTrue(report.ok, report.errors)
         self.assertTrue(report.ready, report.errors)
 

--- a/skills/build-resume-portfolio-site/scripts/test_validate_vite_project.py
+++ b/skills/build-resume-portfolio-site/scripts/test_validate_vite_project.py
@@ -129,6 +129,18 @@ class ValidateViteProjectTests(unittest.TestCase):
             report = validate_vite_project(root, "media-direction")
             self.assertIn("missing_reduced_motion_rule", report.errors)
 
+    def test_integrated_requires_reduced_motion_rule(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            (root / "src" / "styles.css").write_text(
+                ":root { --content-max: 1700px; } "
+                ":focus-visible { outline: 2px solid; }",
+                encoding="utf-8",
+            )
+            report = validate_vite_project(root, "integrated")
+            self.assertIn("missing_reduced_motion_rule", report.errors)
+
     def test_motion_enhanced_accepts_poster_only_media_component(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
@@ -7,95 +7,32 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 
+DECISION_ORDER = (
+    "structure",
+    "typography",
+    "color",
+    "media",
+    "primary_motion",
+    "secondary_motion",
+)
 REQUIRED = {
     "schema_version",
     "spec_id",
     "workflow_mode",
     "content_revision",
-    "visual_protagonist",
-    "fixed_constraints",
-    "open_ceiling",
-    "avoid",
-    "alternatives",
-    "selected_alternative_id",
-    "composition_commitment",
-    "type_color_character",
-    "representative_interaction",
-    "approval",
+    "decision_order",
+    "decisions",
+    "engineering_constraints",
+    "requirements_approval",
+}
+REQUIRED_ENGINEERING_CONSTRAINTS = {
+    "responsive",
+    "accessible",
+    "coarse-pointer",
+    "reduced-motion",
+    "media-fallbacks",
 }
 PLACEHOLDERS = {"todo", "tbd", "implement later", "fill in details"}
-
-
-def _validate_visual_preview(
-    preview: Any,
-    alternative_ids: list[str],
-) -> list[str]:
-    if not isinstance(preview, dict):
-        return ["full mode requires visual_preview"]
-
-    required = {
-        "mode",
-        "artifact",
-        "candidate_ids",
-        "recommended_candidate_id",
-        "selected_candidate_id",
-        "approval_channel",
-        "explicitly_approved",
-    }
-    errors = [
-        f"visual_preview missing field: {name}"
-        for name in sorted(required - set(preview))
-    ]
-    if errors:
-        return errors
-
-    candidate_ids = preview["candidate_ids"]
-    if (
-        not isinstance(candidate_ids, list)
-        or not 2 <= len(candidate_ids) <= 3
-        or not all(
-            isinstance(item, str) and item.strip()
-            for item in candidate_ids
-        )
-        or len(candidate_ids) != len(set(candidate_ids))
-    ):
-        errors.append(
-            "visual_preview candidate_ids must contain "
-            "two or three unique IDs"
-        )
-        candidate_ids = []
-
-    if set(candidate_ids) != set(alternative_ids):
-        errors.append("visual_preview candidate_ids must match alternatives")
-    if preview["mode"] != "local-gallery":
-        errors.append("visual_preview mode must be local-gallery")
-
-    artifact = str(preview["artifact"]).replace("\\", "/")
-    artifact_path = PurePosixPath(artifact)
-    expected_prefix = (
-        ".resume-site-work",
-        "style-preview",
-        "sessions",
-    )
-    if (
-        artifact_path.is_absolute()
-        or ".." in artifact_path.parts
-        or artifact_path.parts[:3] != expected_prefix
-        or len(artifact_path.parts) != 5
-        or artifact_path.parts[-1] != "gallery.html"
-    ):
-        errors.append("visual_preview artifact must be a session gallery")
-
-    for key in ("recommended_candidate_id", "selected_candidate_id"):
-        if preview[key] not in candidate_ids:
-            errors.append(f"visual_preview {key} must reference a candidate")
-    if preview["approval_channel"] != "conversation":
-        errors.append(
-            "visual_preview approval_channel must be conversation"
-        )
-    if preview["explicitly_approved"] is not True:
-        errors.append("visual_preview must be explicitly approved")
-    return errors
 
 
 def _strings(value: Any, *, non_empty: bool = False) -> bool:
@@ -116,6 +53,135 @@ def _contains_placeholder(value: Any) -> bool:
     return False
 
 
+def _validate_approval(approval: Any, subject: str) -> list[str]:
+    verb = "require" if subject == "final requirements" else "requires"
+    if not isinstance(approval, dict):
+        return [f"{subject} {verb} explicit approval"]
+    if approval.get("status") != "user_approved":
+        return [f"{subject} {verb} user approval"]
+    if (
+        approval.get("source") != "explicit_user"
+        or approval.get("channel") != "conversation"
+    ):
+        return [f"{subject} approval must be explicit and conversational"]
+    return []
+
+
+def _validate_preview(preview: Any, category: str) -> list[str]:
+    if not isinstance(preview, dict):
+        return [f"{category} requires a preview record"]
+    errors: list[str] = []
+    if preview.get("offered") is not True:
+        errors.append(f"{category} preview must be offered")
+    response = preview.get("response")
+    delivery = preview.get("delivery")
+    artifact = preview.get("artifact")
+    if response not in {"accepted", "declined"}:
+        errors.append(f"{category} preview response is invalid")
+    if delivery not in {
+        "local-gallery",
+        "static-fallback",
+        "not-requested",
+    }:
+        errors.append(f"{category} preview delivery is invalid")
+    if response == "declined":
+        if delivery != "not-requested" or artifact is not None:
+            errors.append(
+                f"{category} declined preview must not have an artifact"
+            )
+        return errors
+    if delivery == "not-requested":
+        errors.append(f"{category} accepted preview requires delivery")
+    normalized = str(artifact or "").replace("\\", "/")
+    artifact_path = PurePosixPath(normalized)
+    expected_prefix = (
+        ".resume-site-work",
+        "style-preview",
+        "sessions",
+    )
+    if (
+        artifact_path.is_absolute()
+        or ".." in artifact_path.parts
+        or artifact_path.parts[:3] != expected_prefix
+        or len(artifact_path.parts) != 5
+        or artifact_path.parts[-1] != "gallery.html"
+    ):
+        errors.append(
+            f"{category} preview artifact must be a session gallery"
+        )
+    return errors
+
+
+def _validate_candidates(candidates: Any, category: str) -> tuple[list[str], list[str]]:
+    if not isinstance(candidates, list) or len(candidates) < 2:
+        return [], [f"{category} requires at least two candidates"]
+    errors: list[str] = []
+    ids: list[str] = []
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            errors.append(f"{category} candidate[{index}] must be an object")
+            continue
+        candidate_id = candidate.get("id")
+        label = candidate.get("label")
+        tradeoffs = candidate.get("tradeoffs")
+        if not isinstance(candidate_id, str) or not candidate_id.strip():
+            errors.append(f"{category} candidate[{index}] requires an ID")
+            continue
+        ids.append(candidate_id)
+        if not isinstance(label, str) or not label.strip():
+            errors.append(f"{category} candidate[{index}] requires a label")
+        if not _strings(tradeoffs, non_empty=True):
+            errors.append(
+                f"{category} candidate[{index}] requires tradeoffs"
+            )
+    if len(ids) != len(set(ids)):
+        errors.append(f"{category} candidate IDs must be unique")
+    return ids, errors
+
+
+def _validate_confirmed_decision(
+    category: str,
+    decision: Any,
+    *,
+    allow_multiple: bool,
+) -> list[str]:
+    if not isinstance(decision, dict) or decision.get("status") != "confirmed":
+        return [f"{category} must be confirmed"]
+    candidate_ids, errors = _validate_candidates(
+        decision.get("candidates"), category
+    )
+    known = set(candidate_ids)
+    if decision.get("recommended_candidate_id") not in known:
+        errors.append(f"{category} recommendation must reference a candidate")
+    for field in ("tentative_selection_ids", "selected_candidate_ids"):
+        selected = decision.get(field)
+        if not _strings(selected, non_empty=True):
+            errors.append(f"{category} {field} must be non-empty")
+            continue
+        if len(selected) != len(set(selected)):
+            errors.append(f"{category} {field} must be unique")
+        if not allow_multiple and len(selected) != 1:
+            errors.append(
+                f"{category} requires exactly one selected candidate"
+            )
+        if not set(selected) <= known:
+            errors.append(f"{category} {field} must reference candidates")
+    errors.extend(_validate_preview(decision.get("preview"), category))
+    errors.extend(_validate_approval(decision.get("approval"), category))
+    return errors
+
+
+def _validate_media_decision(decision: Any) -> list[str]:
+    if isinstance(decision, dict) and decision.get("status") == "skipped":
+        reason = decision.get("skip_reason")
+        if not isinstance(reason, str) or not reason.strip():
+            return ["media skip requires a reason"]
+        return []
+    return _validate_confirmed_decision(
+        "media", decision, allow_multiple=False
+    )
+
+
 def validate(payload: Any) -> list[str]:
     if not isinstance(payload, dict):
         return ["site design spec must be a JSON object"]
@@ -125,74 +191,69 @@ def validate(payload: Any) -> list[str]:
     ]
     if errors:
         return errors
-    if payload["schema_version"] != 2:
-        errors.append("schema_version must be 2")
+    if payload["schema_version"] != 3:
+        errors.append("schema_version must be 3")
     if payload["workflow_mode"] not in {"full", "fast-change"}:
         errors.append("workflow_mode must be full or fast-change")
-    if not isinstance(payload["content_revision"], int) or payload[
-        "content_revision"
-    ] < 1:
-        errors.append("content_revision must be a positive integer")
-    for name in (
-        "spec_id",
-        "visual_protagonist",
-        "composition_commitment",
-        "type_color_character",
-        "representative_interaction",
+    if (
+        not isinstance(payload["spec_id"], str)
+        or not payload["spec_id"].strip()
     ):
-        if not isinstance(payload[name], str) or not payload[name].strip():
-            errors.append(f"{name} must be a non-empty string")
-    for name in ("fixed_constraints", "open_ceiling", "avoid"):
-        if not _strings(payload[name], non_empty=True):
-            errors.append(f"{name} must be a non-empty string list")
-    fixed = set(payload["fixed_constraints"])
-    avoid = set(payload["avoid"])
-    if fixed & avoid:
-        errors.append("fixed_constraints and avoid must not overlap")
+        errors.append("spec_id must be a non-empty string")
+    if (
+        not isinstance(payload["content_revision"], int)
+        or isinstance(payload["content_revision"], bool)
+        or payload["content_revision"] < 1
+    ):
+        errors.append("content_revision must be a positive integer")
+    if tuple(payload["decision_order"]) != DECISION_ORDER:
+        errors.append("decision_order must match the required workflow order")
 
-    alternatives = payload["alternatives"]
-    if not isinstance(alternatives, list):
-        errors.append("alternatives must be a list")
-        alternatives = []
-    if payload["workflow_mode"] == "full" and not 2 <= len(alternatives) <= 3:
-        errors.append("full mode requires two or three alternatives")
-    ids: list[str] = []
-    families: list[str] = []
-    for index, alternative in enumerate(alternatives):
-        if not isinstance(alternative, dict):
-            errors.append(f"alternative[{index}] must be an object")
-            continue
-        if not {"id", "family", "tradeoffs"} <= set(alternative):
-            errors.append(f"alternative[{index}] is incomplete")
-            continue
-        if not all(
-            isinstance(alternative[name], str) and alternative[name].strip()
-            for name in ("id", "family")
-        ):
-            errors.append(f"alternative[{index}] id and family are required")
-        if not _strings(alternative["tradeoffs"], non_empty=True):
-            errors.append(f"alternative[{index}] requires tradeoffs")
-        ids.append(alternative["id"])
-        families.append(alternative["family"].strip().lower())
-    if len(ids) != len(set(ids)):
-        errors.append("alternative IDs must be unique")
-    if len(families) != len(set(families)):
-        errors.append("layout families must be materially different")
-    if payload["selected_alternative_id"] not in ids:
-        errors.append("selected_alternative_id must reference an alternative")
-    if payload["workflow_mode"] == "full":
-        errors.extend(
-            _validate_visual_preview(payload.get("visual_preview"), ids)
-        )
-
-    approval = payload["approval"]
-    if not isinstance(approval, dict):
-        errors.append("approval must be an object")
+    decisions = payload["decisions"]
+    if not isinstance(decisions, dict):
+        errors.append("decisions must be an object")
     else:
-        if approval.get("status") != "user_approved":
-            errors.append("site design requires user approval")
-        if approval.get("source") != "explicit_user":
-            errors.append("approval source must be explicit_user")
+        missing = set(DECISION_ORDER) - set(decisions)
+        for category in sorted(missing):
+            errors.append(f"decisions missing category: {category}")
+        for category in ("structure", "typography", "color"):
+            if category in decisions:
+                errors.extend(
+                    _validate_confirmed_decision(
+                        category,
+                        decisions[category],
+                        allow_multiple=False,
+                    )
+                )
+        if "media" in decisions:
+            errors.extend(_validate_media_decision(decisions["media"]))
+        if "primary_motion" in decisions:
+            errors.extend(
+                _validate_confirmed_decision(
+                    "primary_motion",
+                    decisions["primary_motion"],
+                    allow_multiple=False,
+                )
+            )
+        if "secondary_motion" in decisions:
+            errors.extend(
+                _validate_confirmed_decision(
+                    "secondary_motion",
+                    decisions["secondary_motion"],
+                    allow_multiple=True,
+                )
+            )
+
+    constraints = payload["engineering_constraints"]
+    if not _strings(constraints, non_empty=True):
+        errors.append("engineering_constraints must be a non-empty string list")
+    elif not REQUIRED_ENGINEERING_CONSTRAINTS <= set(constraints):
+        errors.append("engineering_constraints omit mandatory constraints")
+    errors.extend(
+        _validate_approval(
+            payload["requirements_approval"], "final requirements"
+        )
+    )
     if _contains_placeholder(payload):
         errors.append("placeholder text is not allowed")
     return errors

--- a/skills/build-resume-portfolio-site/scripts/validate_site_implementation_plan.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_site_implementation_plan.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -11,6 +11,9 @@ STRATEGIES = {"single-agent", "fresh-agent-sequential", "parallel-wave"}
 REQUIRED = {
     "schema_version",
     "design_spec_id",
+    "todo_plan",
+    "todo_plan_approval",
+    "generation_mode",
     "strategy",
     "multi_agent_authorized",
     "multi_agent_plan",
@@ -57,8 +60,30 @@ def validate(payload: Any) -> list[str]:
     ]
     if errors:
         return errors
-    if payload["schema_version"] != 1:
-        errors.append("schema_version must be 1")
+    if payload["schema_version"] != 2:
+        errors.append("schema_version must be 2")
+    todo_plan = str(payload["todo_plan"]).replace("\\", "/")
+    if PurePosixPath(todo_plan) != PurePosixPath(
+        ".resume-site-work/reports/site-todo-plan.md"
+    ):
+        errors.append(
+            "todo_plan must reference "
+            ".resume-site-work/reports/site-todo-plan.md"
+        )
+    approval = payload["todo_plan_approval"]
+    if not isinstance(approval, dict):
+        errors.append("todo plan requires user approval")
+    elif approval.get("status") != "user_approved":
+        errors.append("todo plan requires user approval")
+    elif (
+        approval.get("source") != "explicit_user"
+        or approval.get("channel") != "conversation"
+    ):
+        errors.append(
+            "todo plan approval must be explicit and conversational"
+        )
+    if payload["generation_mode"] != "one-integrated-site":
+        errors.append("generation_mode must be one-integrated-site")
     if payload["strategy"] not in STRATEGIES:
         errors.append("unsupported strategy")
     if not isinstance(payload["multi_agent_authorized"], bool):

--- a/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
@@ -11,6 +11,10 @@ from validate_motion_catalog import validate_catalog as validate_motion_catalog
 
 
 PROMPT_SPECS = {
+    "generate-integrated-site": (
+        "01-generate-integrated-site.md",
+        "react-vite-integrated-site",
+    ),
     "generate-prototype": ("01-generate-prototype.md", "react-vite-project"),
     "analyze-reference": ("02-analyze-reference.md", "style-brief-json"),
     "direct-media-art": (
@@ -61,6 +65,11 @@ STAGE_RESOURCES = {
     "planning": (
         "site-planning-contract",
         "site-implementation-plan-schema",
+    ),
+    "integrated": (
+        "generate-integrated-site",
+        "design-catalog",
+        "audit-screenshot",
     ),
     "prototype": ("generate-prototype", "design-catalog"),
     "media-direction": (

--- a/skills/build-resume-portfolio-site/scripts/validate_vite_project.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_vite_project.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import Sequence
 
 
-STAGES = ("prototype", "styled", "media-direction", "refined", "motion", "motion-enhanced", "video-upgrade")
-MOTION_STAGES = {"media-direction", "motion", "motion-enhanced", "video-upgrade"}
+STAGES = ("prototype", "styled", "media-direction", "refined", "integrated", "motion", "motion-enhanced", "video-upgrade")
+MOTION_STAGES = {"media-direction", "integrated", "motion", "motion-enhanced", "video-upgrade"}
 SOURCE_SUFFIXES = {".js", ".jsx", ".ts", ".tsx", ".css", ".scss", ".sass"}
 SKIPPED_DIRS = {"node_modules", "dist", ".git", ".resume-site-work"}
 REGION_PATTERNS = {

--- a/tests/fixtures/site-design-spec-valid.json
+++ b/tests/fixtures/site-design-spec-valid.json
@@ -1,39 +1,80 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "spec_id": "site-spec-1",
   "workflow_mode": "full",
   "content_revision": 1,
-  "visual_protagonist": "project outcomes",
-  "fixed_constraints": ["preserve approved copy"],
-  "open_ceiling": ["composition", "motion language"],
-  "avoid": ["generic card grid"],
-  "alternatives": [
-    {
-      "id": "editorial",
-      "family": "radical editorial",
-      "tradeoffs": ["denser reading rhythm"]
-    },
-    {
-      "id": "cinematic",
-      "family": "cinematic portfolio",
-      "tradeoffs": ["higher media dependency"]
-    }
+  "decision_order": [
+    "structure",
+    "typography",
+    "color",
+    "media",
+    "primary_motion",
+    "secondary_motion"
   ],
-  "selected_alternative_id": "editorial",
-  "composition_commitment": "asymmetric editorial stage",
-  "type_color_character": "high-contrast serif and restrained yellow",
-  "representative_interaction": "project selection updates one detail panel",
-  "visual_preview": {
-    "mode": "local-gallery",
-    "artifact": ".resume-site-work/style-preview/sessions/style-1/gallery.html",
-    "candidate_ids": ["editorial", "cinematic"],
-    "recommended_candidate_id": "editorial",
-    "selected_candidate_id": "editorial",
-    "approval_channel": "conversation",
-    "explicitly_approved": true
+  "decisions": {
+    "structure": {
+      "status": "confirmed",
+      "candidates": [
+        {"id": "editorial", "label": "Editorial", "tradeoffs": ["dense rhythm"]},
+        {"id": "cinematic", "label": "Cinematic", "tradeoffs": ["media dependent"]}
+      ],
+      "recommended_candidate_id": "editorial",
+      "tentative_selection_ids": ["editorial"],
+      "selected_candidate_ids": ["editorial"],
+      "preview": {"offered": true, "response": "declined", "delivery": "not-requested", "artifact": null},
+      "approval": {"status": "user_approved", "source": "explicit_user", "channel": "conversation"}
+    },
+    "typography": {
+      "status": "confirmed",
+      "candidates": [
+        {"id": "serif", "label": "Editorial serif", "tradeoffs": ["formal"]},
+        {"id": "sans", "label": "Technical sans", "tradeoffs": ["less expressive"]}
+      ],
+      "recommended_candidate_id": "serif",
+      "tentative_selection_ids": ["serif"],
+      "selected_candidate_ids": ["serif"],
+      "preview": {"offered": true, "response": "accepted", "delivery": "local-gallery", "artifact": ".resume-site-work/style-preview/sessions/typography-1/gallery.html"},
+      "approval": {"status": "user_approved", "source": "explicit_user", "channel": "conversation"}
+    },
+    "color": {
+      "status": "confirmed",
+      "candidates": [
+        {"id": "ink-yellow", "label": "Ink and yellow", "tradeoffs": ["strong contrast"]},
+        {"id": "paper-red", "label": "Paper and red", "tradeoffs": ["warmer"]}
+      ],
+      "recommended_candidate_id": "ink-yellow",
+      "tentative_selection_ids": ["ink-yellow"],
+      "selected_candidate_ids": ["ink-yellow"],
+      "preview": {"offered": true, "response": "declined", "delivery": "not-requested", "artifact": null},
+      "approval": {"status": "user_approved", "source": "explicit_user", "channel": "conversation"}
+    },
+    "media": {"status": "skipped", "skip_reason": "no authorized media"},
+    "primary_motion": {
+      "status": "confirmed",
+      "candidates": [
+        {"id": "section-reveal", "label": "Section reveal", "tradeoffs": ["restrained"]},
+        {"id": "scroll-narrative", "label": "Scroll narrative", "tradeoffs": ["more controller ownership"]}
+      ],
+      "recommended_candidate_id": "section-reveal",
+      "tentative_selection_ids": ["section-reveal"],
+      "selected_candidate_ids": ["section-reveal"],
+      "preview": {"offered": true, "response": "declined", "delivery": "not-requested", "artifact": null},
+      "approval": {"status": "user_approved", "source": "explicit_user", "channel": "conversation"}
+    },
+    "secondary_motion": {
+      "status": "confirmed",
+      "candidates": [
+        {"id": "card-feedback", "label": "Card feedback", "tradeoffs": ["pointer specific"]},
+        {"id": "text-reveal", "label": "Text reveal", "tradeoffs": ["timing coordination"]},
+        {"id": "media-parallax", "label": "Media parallax", "tradeoffs": ["mobile fallback"]}
+      ],
+      "recommended_candidate_id": "card-feedback",
+      "tentative_selection_ids": ["card-feedback"],
+      "selected_candidate_ids": ["card-feedback", "text-reveal"],
+      "preview": {"offered": true, "response": "declined", "delivery": "not-requested", "artifact": null},
+      "approval": {"status": "user_approved", "source": "explicit_user", "channel": "conversation"}
+    }
   },
-  "approval": {
-    "status": "user_approved",
-    "source": "explicit_user"
-  }
+  "engineering_constraints": ["responsive", "accessible", "coarse-pointer", "reduced-motion", "media-fallbacks"],
+  "requirements_approval": {"status": "user_approved", "source": "explicit_user", "channel": "conversation"}
 }

--- a/tests/fixtures/site-plan-valid.json
+++ b/tests/fixtures/site-plan-valid.json
@@ -1,23 +1,30 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "design_spec_id": "site-spec-1",
+  "todo_plan": ".resume-site-work/reports/site-todo-plan.md",
+  "todo_plan_approval": {
+    "status": "user_approved",
+    "source": "explicit_user",
+    "channel": "conversation"
+  },
+  "generation_mode": "one-integrated-site",
   "strategy": "single-agent",
   "multi_agent_authorized": false,
   "multi_agent_plan": null,
   "tasks": [
     {
-      "id": "prototype-shell",
+      "id": "integrated-site",
       "depends_on": [],
       "files": ["src/App.jsx", "src/styles.css"],
-      "consumes": ["approved-copy.json", "site-design-spec.json"],
-      "produces": ["five-region prototype"],
-      "acceptance": ["Representative interaction is rendered."],
+      "consumes": ["approved-copy.json", "site-design-spec.json", "site-todo-plan.md"],
+      "produces": ["complete integrated portfolio"],
+      "acceptance": ["All six confirmed design decisions are integrated."],
       "verification": [
-        "python validate_vite_project.py .resume-site-work/site --stage prototype",
+        "python validate_vite_project.py .resume-site-work/site --stage integrated",
         "npm run build"
       ]
     }
   ],
   "rollback_baseline": "empty/new site",
-  "snapshot_target": "versions/v1-prototype"
+  "snapshot_target": "versions/v1-integrated"
 }

--- a/tests/test_visual_companion.py
+++ b/tests/test_visual_companion.py
@@ -344,8 +344,11 @@ class VisualCompanionPackageTests(unittest.TestCase):
         self.assertNotIn("<form", text)
         self.assertNotIn("data-choice", text)
         self.assertNotIn("<button", text)
-        self.assertIn("approve in the conversation", text)
-        self.assertIn("<!-- visual-directions -->", text)
+        self.assertIn("return to the conversation", text)
+        self.assertIn("<!-- preview-category -->", text)
+        self.assertIn("<!-- visual-candidates -->", text)
+        self.assertNotIn("onclick=", text)
+        self.assertNotIn("onchange=", text)
 
     def test_visual_companion_resources_are_packaged(self) -> None:
         skill_root = ROOT / "skills" / "build-resume-portfolio-site"

--- a/tests/test_workflow_behavior_contract.py
+++ b/tests/test_workflow_behavior_contract.py
@@ -16,6 +16,15 @@ class WorkflowBehaviorContractTests(unittest.TestCase):
     def read_skill(self, name: str) -> str:
         return (ROOT / "skills" / name / "SKILL.md").read_text(encoding="utf-8")
 
+    def read_site_reference(self, name: str) -> str:
+        return (
+            ROOT
+            / "skills"
+            / "build-resume-portfolio-site"
+            / "references"
+            / name
+        ).read_text(encoding="utf-8")
+
     def run_validator(
         self,
         skill: str,
@@ -104,6 +113,57 @@ class WorkflowBehaviorContractTests(unittest.TestCase):
         self.assertIn("style-preview", layout)
         self.assertIn("discovery evidence", layout)
         self.assertIn("not react source", layout)
+
+    def test_full_discovery_orders_six_independent_decisions(self) -> None:
+        contract = self.read_site_reference(
+            "site-brainstorming-contract.md"
+        ).lower()
+        markers = (
+            "overall structure",
+            "typography",
+            "color system",
+            "media treatment",
+            "primary motion",
+            "secondary motion",
+            "final requirements confirmation",
+            "todo plan approval",
+        )
+        positions = [contract.index(marker) for marker in markers]
+        self.assertEqual(positions, sorted(positions))
+
+    def test_each_enabled_decision_gets_a_separate_preview_offer(self) -> None:
+        contract = self.read_site_reference(
+            "visual-style-preview-contract.md"
+        ).lower()
+        self.assertIn("ask separately for every enabled category", contract)
+        self.assertIn("independent, not cumulative", contract)
+        self.assertIn("declining one category", contract)
+
+    def test_site_skill_requires_readable_plan_approval_before_source_edits(
+        self,
+    ) -> None:
+        text = self.read_skill("build-resume-portfolio-site").lower()
+        self.assertIn("site-todo-plan.md", text)
+        self.assertIn("todo plan approval", text)
+        self.assertIn("do not edit react source", text)
+        self.assertIn("one integrated", text)
+
+    def test_final_acceptance_has_three_explicit_outcomes(self) -> None:
+        skill = self.read_skill("build-resume-portfolio-site")
+        for choice in (
+            "当前效果满意，完成",
+            "加强动效",
+            "提出修改",
+        ):
+            self.assertIn(choice, skill)
+        workflow = self.read_site_reference("workflow-contract.md").lower()
+        for preserved in (
+            "structure",
+            "typography",
+            "color",
+            "media treatment",
+        ):
+            self.assertIn(preserved, workflow)
 
     def test_readme_documents_cross_agent_visual_preview(self) -> None:
         readme = (ROOT / "README.md").read_text(encoding="utf-8").lower()

--- a/tests/test_workflow_behavior_contract.py
+++ b/tests/test_workflow_behavior_contract.py
@@ -212,46 +212,52 @@ class WorkflowBehaviorContractTests(unittest.TestCase):
             "build-resume-portfolio-site",
             "validate_site_design_spec.py",
             "site-design-spec-valid.json",
-            lambda payload: payload.update(
-                {"alternatives": payload["alternatives"][:1]}
+            lambda payload: payload["decisions"]["structure"].update(
+                {
+                    "candidates": payload["decisions"]["structure"][
+                        "candidates"
+                    ][:1]
+                }
             ),
         )
         self.assertNotEqual(result.returncode, 0)
 
-    def test_full_site_requires_visual_preview(self) -> None:
+    def test_full_site_requires_a_preview_record_per_enabled_category(self) -> None:
         result = self.run_validator(
             "build-resume-portfolio-site",
             "validate_site_design_spec.py",
             "site-design-spec-valid.json",
-            lambda payload: payload.pop("visual_preview"),
+            lambda payload: payload["decisions"]["structure"].pop("preview"),
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("full mode requires visual_preview", result.stdout)
+        self.assertIn("structure requires a preview record", result.stdout)
 
     def test_browser_activity_cannot_approve_site_design(self) -> None:
         result = self.run_validator(
             "build-resume-portfolio-site",
             "validate_site_design_spec.py",
             "site-design-spec-valid.json",
-            lambda payload: payload["visual_preview"].update(
-                {"approval_channel": "browser"}
+            lambda payload: payload["decisions"]["structure"][
+                "approval"
+            ].update(
+                {"channel": "browser"}
             ),
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "visual_preview approval_channel must be conversation",
+            "structure approval must be explicit and conversational",
             result.stdout,
         )
 
-    def test_version_one_site_design_is_rejected(self) -> None:
+    def test_version_two_site_design_is_rejected(self) -> None:
         result = self.run_validator(
             "build-resume-portfolio-site",
             "validate_site_design_spec.py",
             "site-design-spec-valid.json",
-            lambda payload: payload.update({"schema_version": 1}),
+            lambda payload: payload.update({"schema_version": 2}),
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("schema_version must be 2", result.stdout)
+        self.assertIn("schema_version must be 3", result.stdout)
 
     def test_unsupported_claim_cannot_enter_content_plan(self) -> None:
         def remove_evidence(payload: dict) -> None:


### PR DESCRIPTION
## Summary

- add six upfront portfolio decisions: structure, typography, color, conditional media, primary motion, and compatible secondary motion
- offer an independent display-only browser preview after each enabled decision, with approval recorded only in conversation
- require schema-v3 design approval plus an explicitly approved readable TODO plan and schema-v2 implementation plan
- generate one integrated React + Vite website only after planning approval
- finish with exactly three outcomes: accept, strengthen motion, or request changes
- support and verify standalone global Skill installation

## Verification

- repository tests: 34 passed
- Skill tests: 210 passed
- installed Skill tests: 210 passed, 3 repository-only plugin metadata checks skipped
- discovery, planning, and integrated resource validation passed
- source and installed Skill: 142 files, zero hash differences