### PR TITLE
feat: 让六项视觉决策由设计数据库前置驱动

### DIFF
--- a/skills/build-resume-portfolio-site/SKILL.md
+++ b/skills/build-resume-portfolio-site/SKILL.md
@@ -107,7 +107,7 @@ python "$SKILL_ROOT\scripts\validate_content_quality_review.py" `
 
 ## Full discovery gate
 
-Use the full route for a new site or a change to audience, overall structure,
+Use the full route for a new site or a change to audience, site composition,
 visual thesis, interaction architecture, or implementation strategy.
 
 1. Validate `discovery` resources.
@@ -117,28 +117,66 @@ visual thesis, interaction architecture, or implementation strategy.
    generated `reference-library/contact-sheets`, record chosen evidence in
    `reports/reference-selection.json`, respect `style_only` usage, and render
    local evidence with absolute Markdown image paths.
-3. Ask one question at a time and complete these categories in exact order:
+3. Generate `.resume-site-work/reports/content-map.json` only from normalized
+   facts and approved copy. Keep only the privacy-safe role, industry, content
+   density, media profile, and skill/topic keywords used by design retrieval.
+   Before asking the first design question, set
+   `stage=design_baseline_generating` and run:
+
+```powershell
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" baseline `
+  --content-map ".resume-site-work\reports\content-map.json" `
+  --output ".resume-site-work\reports\design-discovery\baseline.json"
+python "$SKILL_ROOT\scripts\validate_design_discovery.py" `
+  ".resume-site-work\reports\design-discovery\baseline.json" `
+  --expected-type baseline
+```
+
+   If a reference selection exists, also pass `--reference-selection`. On
+   success set `stage=design_baseline_ready`; on catalog insufficiency stop and
+   report the exact missing evidence instead of inventing a direction.
+4. Initialize `reports/design-decisions-working.json`. Before presenting each
+   category, run the matching query below. Every later query reads all prior
+   conversationally approved IDs through `inherited_decision_ids`:
+
+```powershell
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category structure --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\structure.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category typography --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\typography.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category color --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\color.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category media --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\media.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category primary_motion --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\primary-motion.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category secondary_motion --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\secondary-motion.json"
+```
+
+   These are six sequential transactions, not one batch: run only the current
+   category command, validate its report with `validate_design_discovery.py
+   --expected-type category`, present only its database-backed candidates, then
+   persist the approved selection before running the next command. A report
+   without non-empty `source_ids`, or with fewer than two candidates, cannot be
+   presented as database output.
+5. Ask one question at a time and complete these categories in exact order:
    overall structure, typography, color system, conditional media treatment,
    primary motion, and secondary motion.
-4. For every enabled category, compare candidates and recommend one with fit,
+6. For every enabled category, compare candidates and recommend one with fit,
    risk, and trade-offs. Then separately ask whether to open the browser
    comparison before requesting the user's choice.
-5. On acceptance, follow `visual-style-preview-contract.md`, create an
+7. On acceptance, follow `visual-style-preview-contract.md`, create an
    independent display-only `gallery.html`, run `launch.cjs --open`, and give
    the user the complete authenticated URL plus the absolute static HTML fallback.
    On decline, record the decline and continue text-only. Previous
    consent never applies to the next category.
-6. After the preview or decline, receive the user's selection and final category
+8. After the preview or decline, receive the user's selection and final category
    confirmation in the conversation. Approval remains in the conversation:
    browser visits, reloads, screenshots, and launch events do not select,
    approve, or advance state.
-7. Media may be skipped only with an explicit reason. Select exactly one
+9. Media may be skipped only with an explicit reason and conversational
+   approval. Select exactly one
    primary-motion system. Secondary motion may contain multiple compatible
    effects without a fixed numeric cap.
-8. Summarize all decisions and mandatory responsive, accessibility,
+10. Summarize all decisions and mandatory responsive, accessibility,
    coarse-pointer, fallback, and reduced-motion constraints. Obtain final
    requirements confirmation.
-9. Write schema-version-3
+11. Write schema-version-3
    `.resume-site-work/reports/site-design-spec.json` and validate it:
 
 ```powershell

--- a/skills/build-resume-portfolio-site/SKILL.md
+++ b/skills/build-resume-portfolio-site/SKILL.md
@@ -242,18 +242,23 @@ integration, preview promotion, snapshots, and publication.
 
 1. Validate `integrated` resources and set `stage=design_contract_compiling`.
 2. Read `prompts/01-generate-integrated-site.md`.
-3. Generate `reports/content-map.json` only from normalized facts and approved
-   copy. Before React generation, run:
+3. Reuse the discovery-stage `reports/content-map.json`, validated baseline,
+   six category reports, and approved site design spec. Compile them before
+   React generation:
 
 ```powershell
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" recommend `
-  --input ".resume-site-work\reports\content-map.json" `
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" aggregate `
+  --content-map ".resume-site-work\reports\content-map.json" `
+  --baseline ".resume-site-work\reports\design-discovery\baseline.json" `
+  --reports-dir ".resume-site-work\reports\design-discovery" `
+  --site-design-spec ".resume-site-work\reports\site-design-spec.json" `
   --output ".resume-site-work\reports\design-intelligence.json"
 ```
 
-   Treat `reports\design-intelligence.json` as soft guidance. Translate the
-   approved decisions into `reports/creative-direction.json` and validate it;
-   the report may add implementation detail but cannot reopen user choices.
+   The aggregate is fixed approved input, not a new recommendation. Do not rerun
+   generic catalog recommendation here. Translate its selected candidates into
+   `reports/creative-direction.json` and validate it; implementation may resolve
+   open details but cannot reopen or contradict user choices.
 4. Compile the approved design specification, design intelligence, and creative
    direction into a temporary sibling for `reports/design-contract.json`. Follow
    `references/design-contract.md`, validate the temporary report, and atomically

--- a/skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md
+++ b/skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md
@@ -19,12 +19,18 @@ Read and preserve:
 - `reports/site-design-spec.json` schema version 3;
 - `reports/site-todo-plan.md` as the user-approved readable plan;
 - `reports/site-implementation-plan.json` schema version 2;
-- `reports/design-intelligence.json` as soft design guidance;
+- `reports/design-intelligence.json` in `approved-discovery` mode as the
+  database-backed baseline and fixed selected-candidate evidence;
 - validated `reports/design-contract.json` as observable implementation and
   acceptance commitments;
 - `reports/media-inventory.json` when authorized media exists.
 
 Do not implement when final requirements or TODO plan approval is missing.
+Do not select a different catalog candidate, rerun a generic recommendation,
+or treat an unselected candidate as implementation freedom. Open details inside
+the approved candidates remain implementation freedom only when they do not
+contradict the six confirmed decisions, responsive fallbacks, accessibility
+notes, or source-linked constraints.
 
 ## Integrated implementation
 

--- a/skills/build-resume-portfolio-site/references/artifact-layout.md
+++ b/skills/build-resume-portfolio-site/references/artifact-layout.md
@@ -37,6 +37,15 @@ Create all generated material under `.resume-site-work/` in the active user work
 |   |-- content-implementation-plan.json
 |   |-- content-quality-review.json # evidence, writing, ATS, JD, and copy approval gate
 |   |-- jd-match.json               # only when a JD is supplied
+|   |-- design-decisions-working.json # approved IDs accumulated during discovery
+|   |-- design-discovery/
+|   |   |-- baseline.json
+|   |   |-- structure.json
+|   |   |-- typography.json
+|   |   |-- color.json
+|   |   |-- media.json
+|   |   |-- primary-motion.json
+|   |   `-- secondary-motion.json
 |   |-- creative-direction.json    # fixed floor, open ceiling, and selected layout family
 |   |-- design-contract.json       # compiled observable design and acceptance commitments
 |   |-- multi-agent-implementation.json # only when multi-agent execution is authorized
@@ -90,6 +99,14 @@ React source edits. The
 creative-direction report may translate the approved design spec into
 implementation detail but may not contradict it.
 
+`reports/design-discovery/baseline.json` records the three database-backed
+directions created before the first visual question. Each category report
+records its exact catalog domains, privacy-safe query context, inherited prior
+decision IDs, candidates, recommendation, and source IDs. The working decision
+file contains only approved candidate IDs and conversational approval metadata;
+it is the inheritance input for the next category and has no independent
+approval semantics.
+
 `reports/multi-agent-implementation.json` exists only when the user explicitly
 selects parallel multi-Agent implementation. It records the parallel-wave
 strategy, dependencies,
@@ -108,6 +125,17 @@ Initialize `build-state.json` with this minimum shape:
   "skill_version": "1.2.0-react-vite",
   "workflow_mode": "full",
   "discovery": {
+    "design_discovery": {
+      "baseline": "reports/design-discovery/baseline.json",
+      "categories": {
+        "structure": "reports/design-discovery/structure.json",
+        "typography": "reports/design-discovery/typography.json",
+        "color": "reports/design-discovery/color.json",
+        "media": "reports/design-discovery/media.json",
+        "primary_motion": "reports/design-discovery/primary-motion.json",
+        "secondary_motion": "reports/design-discovery/secondary-motion.json"
+      }
+    },
     "site_design_approved": false,
     "site_plan_validated": false
   },

--- a/skills/build-resume-portfolio-site/references/design-discovery-schema.json
+++ b/skills/build-resume-portfolio-site/references/design-discovery-schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "design-discovery-schema.json",
+  "title": "Database-first portfolio design discovery report",
+  "oneOf": [
+    { "$ref": "#/$defs/baseline" },
+    { "$ref": "#/$defs/categoryReport" }
+  ],
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stringList": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/nonEmptyString" }
+    },
+    "nonEmptyStringList": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/nonEmptyString" }
+    },
+    "queryProfile": {
+      "type": "object",
+      "required": ["role", "industry", "content_density", "media_profile", "keywords"],
+      "properties": {
+        "role": { "$ref": "#/$defs/nonEmptyString" },
+        "industry": { "$ref": "#/$defs/nonEmptyString" },
+        "content_density": { "$ref": "#/$defs/nonEmptyString" },
+        "media_profile": { "$ref": "#/$defs/nonEmptyString" },
+        "keywords": { "$ref": "#/$defs/stringList" }
+      },
+      "additionalProperties": false
+    },
+    "queryContext": {
+      "allOf": [
+        { "$ref": "#/$defs/queryProfile" },
+        {
+          "type": "object",
+          "required": ["baseline_direction_id", "approved_decision_ids"],
+          "properties": {
+            "baseline_direction_id": { "$ref": "#/$defs/nonEmptyString" },
+            "approved_decision_ids": { "$ref": "#/$defs/stringList" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["upstream", "catalog_version"],
+      "properties": {
+        "upstream": { "$ref": "#/$defs/nonEmptyString" },
+        "catalog_version": { "$ref": "#/$defs/nonEmptyString" },
+        "domains": { "$ref": "#/$defs/nonEmptyStringList" }
+      },
+      "additionalProperties": false
+    },
+    "direction": {
+      "type": "object",
+      "required": [
+        "id", "name", "style_family", "composition", "color_relationships",
+        "typography_roles", "surface_language", "media_strategy", "fit_reasons",
+        "risks", "source_ids"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "style_family": { "$ref": "#/$defs/nonEmptyString" },
+        "composition": { "$ref": "#/$defs/nonEmptyString" },
+        "color_relationships": { "$ref": "#/$defs/nonEmptyStringList" },
+        "typography_roles": {
+          "type": "object",
+          "required": ["display", "body", "hierarchy"],
+          "properties": {
+            "display": { "$ref": "#/$defs/nonEmptyString" },
+            "body": { "$ref": "#/$defs/nonEmptyString" },
+            "hierarchy": { "$ref": "#/$defs/nonEmptyString" }
+          },
+          "additionalProperties": false
+        },
+        "surface_language": { "$ref": "#/$defs/nonEmptyString" },
+        "media_strategy": { "$ref": "#/$defs/nonEmptyString" },
+        "fit_reasons": { "$ref": "#/$defs/nonEmptyStringList" },
+        "risks": { "$ref": "#/$defs/nonEmptyStringList" },
+        "source_ids": { "$ref": "#/$defs/nonEmptyStringList" }
+      },
+      "additionalProperties": false
+    },
+    "candidate": {
+      "type": "object",
+      "required": [
+        "id", "label", "fit", "risks", "tradeoffs", "compatibility",
+        "responsive_fallback", "accessibility_notes", "source_ids"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "label": { "$ref": "#/$defs/nonEmptyString" },
+        "fit": { "$ref": "#/$defs/nonEmptyStringList" },
+        "risks": { "$ref": "#/$defs/nonEmptyStringList" },
+        "tradeoffs": { "$ref": "#/$defs/nonEmptyStringList" },
+        "compatibility": { "$ref": "#/$defs/stringList" },
+        "responsive_fallback": { "$ref": "#/$defs/nonEmptyString" },
+        "accessibility_notes": { "$ref": "#/$defs/nonEmptyStringList" },
+        "source_ids": { "$ref": "#/$defs/nonEmptyStringList" }
+      },
+      "additionalProperties": false
+    },
+    "baseline": {
+      "type": "object",
+      "required": [
+        "schema_version", "report_type", "mode", "query", "candidate_directions",
+        "selected_direction_id", "guardrails", "react_guidelines",
+        "reference_selection_ids", "provenance"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "report_type": { "const": "baseline" },
+        "mode": { "const": "baseline" },
+        "query": { "$ref": "#/$defs/queryProfile" },
+        "candidate_directions": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "$ref": "#/$defs/direction" }
+        },
+        "selected_direction_id": { "$ref": "#/$defs/nonEmptyString" },
+        "guardrails": { "$ref": "#/$defs/stringList" },
+        "react_guidelines": { "$ref": "#/$defs/stringList" },
+        "reference_selection_ids": { "$ref": "#/$defs/stringList" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "categoryReport": {
+      "type": "object",
+      "required": [
+        "schema_version", "report_type", "category", "query_context",
+        "domains_searched", "inherited_decision_ids", "candidates",
+        "recommended_candidate_id", "provenance"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "report_type": { "const": "category" },
+        "category": {
+          "enum": ["structure", "typography", "color", "media", "primary_motion", "secondary_motion"]
+        },
+        "query_context": { "$ref": "#/$defs/queryContext" },
+        "domains_searched": { "$ref": "#/$defs/nonEmptyStringList" },
+        "inherited_decision_ids": { "$ref": "#/$defs/stringList" },
+        "candidates": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/candidate" }
+        },
+        "recommended_candidate_id": { "$ref": "#/$defs/nonEmptyString" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/skills/build-resume-portfolio-site/references/design-intelligence-contract.md
+++ b/skills/build-resume-portfolio-site/references/design-intelligence-contract.md
@@ -18,6 +18,12 @@ Enrichment mode additionally accepts an approved `StyleBrief`. Visible
 reference evidence has priority over Catalog aesthetics. Catalog accessibility,
 responsive, privacy, and implementation guardrails remain mandatory.
 
+Approved-discovery mode consumes the validated baseline, all six validated
+category reports, and the approved site design specification. It copies only
+the candidates selected in the conversation, preserving their report paths and
+catalog source IDs. It is the canonical generation input and cannot recommend a
+different direction or reopen a decision.
+
 ## Candidate rules
 
 - Return exactly three candidates in recommendation mode.
@@ -30,6 +36,10 @@ responsive, privacy, and implementation guardrails remain mandatory.
   explicit retry or user selection.
 - Do not silently invent fixed fallback directions when the Catalog cannot
   provide three valid candidates.
+- In approved-discovery mode, require every category report, require explicit
+  conversational approval, and verify every selected ID exists in that report.
+  A skipped media decision retains its validated report and approval but has no
+  selected candidate.
 
 ## Persistence
 
@@ -37,6 +47,11 @@ Write the report to `.resume-site-work/reports/design-intelligence.json` using
 a temporary sibling file and atomic replacement. Preserve
 `selected_direction_id` through later stages. Record attempted direction IDs
 when a prototype is rejected.
+
+For integrated generation, write one `approved-discovery` aggregate from the
+persisted baseline and category reports. Do not rerun `recommend`; the aggregate
+preserves the exact approved IDs, selected candidate records, discovery-report
+paths, guardrails, React guidance, and catalog provenance.
 
 ## Privacy
 

--- a/skills/build-resume-portfolio-site/references/design-intelligence-schema.json
+++ b/skills/build-resume-portfolio-site/references/design-intelligence-schema.json
@@ -4,10 +4,10 @@
   "title": "Portfolio design intelligence",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "mode", "query", "candidate_directions", "selected_direction_id", "guardrails", "react_guidelines", "provenance"],
+  "required": ["schema_version", "mode", "query", "guardrails", "react_guidelines", "provenance"],
   "properties": {
     "schema_version": {"const": 1},
-    "mode": {"enum": ["recommend", "enrich"]},
+    "mode": {"enum": ["recommend", "enrich", "approved-discovery"]},
     "query": {
       "type": "object",
       "additionalProperties": false,
@@ -25,6 +25,8 @@
     "guardrails": {"type": "array", "items": {"type": "string"}},
     "react_guidelines": {"type": "array", "items": {"type": "string"}},
     "reference_evidence_priority": {"type": "boolean"},
+    "baseline": {"type": "object"},
+    "approved_decisions": {"$ref": "#/$defs/approvedDecisions"},
     "provenance": {
       "type": "object",
       "additionalProperties": false,
@@ -36,6 +38,13 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": {"properties": {"mode": {"const": "approved-discovery"}}},
+      "then": {"required": ["baseline", "approved_decisions"]},
+      "else": {"required": ["candidate_directions", "selected_direction_id"]}
+    }
+  ],
   "$defs": {
     "direction": {
       "type": "object",
@@ -62,6 +71,46 @@
         "fit_reasons": {"type": "array", "items": {"type": "string"}},
         "risks": {"type": "array", "items": {"type": "string"}},
         "source_ids": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+      }
+    },
+    "discoveryCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "fit", "risks", "tradeoffs", "compatibility", "responsive_fallback", "accessibility_notes", "source_ids"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "fit": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "risks": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "tradeoffs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "compatibility": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "responsive_fallback": {"type": "string", "minLength": 1},
+        "accessibility_notes": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "source_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "approvedDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "selected_candidate_ids", "selected_candidates", "discovery_report"],
+      "properties": {
+        "status": {"enum": ["confirmed", "skipped"]},
+        "selected_candidate_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "selected_candidates": {"type": "array", "items": {"$ref": "#/$defs/discoveryCandidate"}},
+        "discovery_report": {"type": "string", "pattern": "^\\.resume-site-work/reports/design-discovery/(structure|typography|color|media|primary-motion|secondary-motion)\\.json$"}
+      }
+    },
+    "approvedDecisions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["structure", "typography", "color", "media", "primary_motion", "secondary_motion"],
+      "properties": {
+        "structure": {"$ref": "#/$defs/approvedDecision"},
+        "typography": {"$ref": "#/$defs/approvedDecision"},
+        "color": {"$ref": "#/$defs/approvedDecision"},
+        "media": {"$ref": "#/$defs/approvedDecision"},
+        "primary_motion": {"$ref": "#/$defs/approvedDecision"},
+        "secondary_motion": {"$ref": "#/$defs/approvedDecision"}
       }
     }
   }

--- a/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
+++ b/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
@@ -6,8 +6,10 @@ visual thesis, interaction architecture, or implementation strategy.
 ## Required decision order
 
 Inspect approved content, authorized media, references, existing state, and
-confirmed artifacts before asking questions. Ask one decision-bearing question
-at a time and complete these decisions in order:
+confirmed artifacts before asking questions. Build and validate the privacy-safe
+content map, then query the vendored design catalog for a three-direction
+baseline before the first question. Ask one decision-bearing question at a time
+and complete these decisions in order:
 
 1. **Overall structure** — composition, hierarchy, navigation, and content density.
 2. **Typography** — type character, scale, rhythm, and reading texture.
@@ -31,17 +33,26 @@ and reduced motion are requirements, not optional style choices.
 
 For each enabled category:
 
-1. Compare two or three materially different candidates, except secondary
+1. Set `design_<category>_querying`. Query the category's required catalog
+   domains using the baseline plus every prior conversationally approved
+   decision ID. Write and validate
+   `reports/design-discovery/<category>.json` before showing candidates.
+2. If retrieval returns fewer than two complete candidates or any candidate
+   lacks `source_ids`, stop with `design_catalog_insufficient`; do not synthesize
+   a database candidate.
+3. Set `design_<category>_selecting`. Compare two or three materially different candidates, except secondary
    motion may offer more compatible effects without a fixed numeric cap.
-2. Recommend one candidate or compatible set and state fit, risk, and trade-offs.
-3. Ask whether to open the browser comparison in a separate message before
+4. Recommend one candidate or compatible set and state fit, risk, trade-offs,
+   compatibility, responsive fallback, accessibility notes, and catalog source IDs.
+5. Ask whether to open the browser comparison in a separate message before
    requesting a choice for this category.
-4. If accepted, follow `visual-style-preview-contract.md`; if declined, record
+6. If accepted, follow `visual-style-preview-contract.md`; if declined, record
    `not-requested` and continue text-only.
-5. Receive the user's selection in the conversation after the preview or
+7. Receive the user's selection in the conversation after the preview or
    decline.
-6. Receive explicit confirmation, revision, or rejection in the conversation.
-7. Lock the decision before entering the next category.
+8. Receive explicit confirmation, revision, or rejection in the conversation.
+9. Lock the decision, its discovery report, and selected source-linked IDs in
+   `design-decisions-working.json` before entering the next category.
 
 An accepted preview produces a display-only `gallery.html` outside the React
 source project.
@@ -51,10 +62,18 @@ and never advances state. It also never counts as selection. Do not repeatedly
 offer a category after the user declines its preview. When media is explicitly
 skipped, record the reason and do not offer a media preview.
 
+The exact domain sequence is structure=`landing/style/product/ux`,
+typography=`typography/style/ux`, color=`color/style/ux`,
+media=`style/product/landing/ux`, primary motion=`motion/style/landing/ux`, and
+secondary motion=`motion/react/ux`. Each query inherits the baseline direction
+and all prior approved decision IDs; it never uses names, contact details, raw
+resume paragraphs, or project secrets.
+
 After final requirements confirmation, write schema-version-3
 `.resume-site-work/reports/site-design-spec.json` and validate it before
-planning. A changed core decision invalidates final requirements approval and
-all downstream planning artifacts.
+planning. A changed core decision invalidates only downstream category reports,
+final requirements approval, TODO approval, and the implementation plan. Rerun
+those downstream database queries with the revised inherited choices.
 
 Do not create or edit React source during discovery or planning.
 

--- a/skills/build-resume-portfolio-site/references/site-design-spec-schema.json
+++ b/skills/build-resume-portfolio-site/references/site-design-spec-schema.json
@@ -72,13 +72,49 @@
     "candidate": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "label", "tradeoffs"],
+      "required": [
+        "id",
+        "label",
+        "fit",
+        "risks",
+        "tradeoffs",
+        "compatibility",
+        "responsive_fallback",
+        "accessibility_notes",
+        "source_ids"
+      ],
       "properties": {
         "id": {"type": "string", "minLength": 1},
         "label": {"type": "string", "minLength": 1},
+        "fit": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "risks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
         "tradeoffs": {
           "type": "array",
           "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "compatibility": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "responsive_fallback": {"type": "string", "minLength": 1},
+        "accessibility_notes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "source_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
           "items": {"type": "string", "minLength": 1}
         }
       }
@@ -131,6 +167,7 @@
       "additionalProperties": false,
       "required": [
         "status",
+        "discovery_report",
         "candidates",
         "recommended_candidate_id",
         "tentative_selection_ids",
@@ -140,6 +177,10 @@
       ],
       "properties": {
         "status": {"const": "confirmed"},
+        "discovery_report": {
+          "type": "string",
+          "pattern": "^\\.resume-site-work/reports/design-discovery/(structure|typography|color|media|primary-motion|secondary-motion)\\.json$"
+        },
         "candidates": {
           "type": "array",
           "minItems": 2,
@@ -178,10 +219,11 @@
     "skippedMedia": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["status", "skip_reason"],
+      "required": ["status", "skip_reason", "approval"],
       "properties": {
         "status": {"const": "skipped"},
-        "skip_reason": {"type": "string", "minLength": 1}
+        "skip_reason": {"type": "string", "minLength": 1},
+        "approval": {"$ref": "#/$defs/approval"}
       }
     }
   }

--- a/skills/build-resume-portfolio-site/references/workflow-contract.md
+++ b/skills/build-resume-portfolio-site/references/workflow-contract.md
@@ -13,12 +13,14 @@ content_preflight
 -> content_plan_generating
 -> content_copy_waiting_confirmation
 -> content_quality_validating
--> design_structure_selecting
--> design_typography_selecting
--> design_color_selecting
--> design_media_selecting OR design_media_skipped
--> design_primary_motion_selecting
--> design_secondary_motion_selecting
+-> design_baseline_generating
+-> design_baseline_ready
+-> design_structure_querying -> design_structure_selecting
+-> design_typography_querying -> design_typography_selecting
+-> design_color_querying -> design_color_selecting
+-> design_media_querying -> design_media_selecting OR design_media_skipped
+-> design_primary_motion_querying -> design_primary_motion_selecting
+-> design_secondary_motion_querying -> design_secondary_motion_selecting
 -> requirements_waiting_confirmation
 -> todo_plan_generating
 -> todo_plan_waiting_confirmation
@@ -34,6 +36,13 @@ Every enabled design state compares candidates and offers its separate browser
 comparison before user selection. An optional independent Gallery supports the
 decision; selection and confirmation happen afterward in the conversation. A
 decline affects only that category.
+
+`CONTENT_READY` first creates the privacy-safe content map. Baseline generation
+queries the vendored catalog and must validate before structure querying begins.
+Each category querying state consumes the same baseline plus every prior
+approved decision ID, emits a validated source-linked report, and only then
+enters selection. `design_catalog_insufficient` freezes selection and preserves
+the last valid reports; it never permits fabricated fallback candidates.
 
 Missing or invalid content stays inside this Skill. The bundled content phase
 establishes fact/evidence records, optional JD matching, explicit strategy
@@ -105,6 +114,9 @@ integrated_waiting_confirmation --提出修改 and core reversal--> affected des
 Motion enhancement preserves content, structure, typography, color, and media treatment. It may revise only primary/secondary motion plans and implementation.
 A core reversal invalidates that decision's downstream evidence, final
 requirements approval, TODO plan approval, and JSON implementation plan.
+The revised category report and every later category report must be regenerated
+in order so their inherited decision IDs remain truthful. Earlier reports remain
+valid and are not rerun.
 
 ## Content preflight
 

--- a/skills/build-resume-portfolio-site/references/workflow-contract.md
+++ b/skills/build-resume-portfolio-site/references/workflow-contract.md
@@ -53,7 +53,7 @@ unmatched unless the user supplies evidence; they never become generated facts.
 
 ```text
 content_copy_waiting_confirmation --approve exact wording--> content_quality_validating
-content_quality_validating --quality and handoff validate--> design_structure_selecting
+content_quality_validating --quality and handoff validate--> design_baseline_generating
 content_quality_validating --invalid or copy changes--> content_copy_waiting_confirmation
 ```
 

--- a/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
+++ b/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from typing import Any
 
 from validate_design_catalog import validate_catalog
+from validate_design_discovery import validate as validate_discovery_report
 
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
@@ -41,6 +42,9 @@ DOMAIN_ID_KEYS = {
     "motion": "Category",
     "react": "Guideline",
     "ux": "Issue",
+}
+DOMAIN_QUERY_HINTS = {
+    "motion": "scroll reveal hover stagger pin scrub interaction",
 }
 WORD_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9+.#-]{1,30}")
 _VENDOR_CORE: ModuleType | None = None
@@ -421,7 +425,12 @@ def _category_candidates(
 ) -> list[dict[str, object]]:
     domains = CATEGORY_DOMAINS[category]
     rows_by_domain = {
-        domain: _search_logical_domain(domain, query, 8) for domain in domains
+        domain: _search_logical_domain(
+            domain,
+            " ".join(filter(None, (query, DOMAIN_QUERY_HINTS.get(domain, "")))),
+            8,
+        )
+        for domain in domains
     }
     available = min((len(rows) for rows in rows_by_domain.values()), default=0)
     return [
@@ -498,6 +507,70 @@ def search_category(
             "upstream": UPSTREAM,
             "catalog_version": validate_catalog(CATALOG_ROOT).catalog_version,
         },
+    }
+
+
+def aggregate_discovery(
+    content_map: Mapping[str, object],
+    baseline: Mapping[str, object],
+    category_reports: Mapping[str, object],
+    design_spec: Mapping[str, object],
+) -> dict[str, object]:
+    if not isinstance(content_map, Mapping):
+        raise ValueError("content map must be a JSON object")
+    if validate_discovery_report(baseline, expected_type="baseline"):
+        raise ValueError("baseline design discovery report is invalid")
+    decisions = _mapping(design_spec.get("decisions"))
+    approved_decisions: dict[str, object] = {}
+    for category in CATEGORY_DOMAINS:
+        report = _mapping(category_reports.get(category))
+        errors = validate_discovery_report(report, expected_type="category")
+        if errors or report.get("category") != category:
+            raise ValueError(f"invalid category report: {category}")
+        decision = _mapping(decisions.get(category))
+        approval = _mapping(decision.get("approval"))
+        if approval.get("status") != "user_approved":
+            raise ValueError(f"category is not user approved: {category}")
+        selected_ids = [
+            _string(item)
+            for item in _sequence(decision.get("selected_candidate_ids"))
+            if _string(item)
+        ]
+        candidates = [
+            _mapping(item) for item in _sequence(report.get("candidates"))
+        ]
+        candidate_by_id = {
+            _string(candidate.get("id")): candidate for candidate in candidates
+        }
+        if decision.get("status") != "skipped":
+            if not selected_ids or not set(selected_ids) <= set(candidate_by_id):
+                raise ValueError(
+                    f"approved IDs do not reference {category} candidates"
+                )
+        report_path = _string(decision.get("discovery_report")) or (
+            ".resume-site-work/reports/design-discovery/"
+            f"{category.replace('_', '-')}.json"
+        )
+        approved_decisions[category] = {
+            "status": _string(decision.get("status"), "confirmed"),
+            "selected_candidate_ids": selected_ids,
+            "selected_candidates": [
+                dict(candidate_by_id[candidate_id])
+                for candidate_id in selected_ids
+            ],
+            "discovery_report": report_path,
+        }
+    return {
+        "schema_version": 1,
+        "mode": "approved-discovery",
+        "query": _content_profile(content_map),
+        "baseline": dict(baseline),
+        "approved_decisions": approved_decisions,
+        "guardrails": list(_sequence(baseline.get("guardrails"))),
+        "react_guidelines": list(
+            _sequence(baseline.get("react_guidelines"))
+        ),
+        "provenance": dict(_mapping(baseline.get("provenance"))),
     }
 
 
@@ -599,6 +672,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     category_parser.add_argument("--baseline", type=Path, required=True)
     category_parser.add_argument("--decisions", type=Path, required=True)
     category_parser.add_argument("--output", type=Path, required=True)
+    aggregate_parser = subparsers.add_parser("aggregate")
+    aggregate_parser.add_argument("--content-map", type=Path, required=True)
+    aggregate_parser.add_argument("--baseline", type=Path, required=True)
+    aggregate_parser.add_argument("--reports-dir", type=Path, required=True)
+    aggregate_parser.add_argument("--site-design-spec", type=Path, required=True)
+    aggregate_parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "recommend":
@@ -618,12 +697,26 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _read_json_object(args.content_map, "content map"),
                 reference_selection,
             )
-        else:
+        elif args.command == "category":
             result = search_category(
                 args.category,
                 _read_json_object(args.content_map, "content map"),
                 _read_json_object(args.baseline, "baseline"),
                 _read_json_object(args.decisions, "decisions"),
+            )
+        else:
+            reports = {
+                category: _read_json_object(
+                    args.reports_dir / f"{category.replace('_', '-')}.json",
+                    f"{category} category report",
+                )
+                for category in CATEGORY_DOMAINS
+            }
+            result = aggregate_discovery(
+                _read_json_object(args.content_map, "content map"),
+                _read_json_object(args.baseline, "baseline"),
+                reports,
+                _read_json_object(args.site_design_spec, "site design spec"),
             )
         _atomic_write_json(args.output, result)
     except DesignCatalogInsufficient as error:

--- a/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
+++ b/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
@@ -24,8 +24,30 @@ STYLE_LENSES = (
     "portfolio modular bento project showcase",
     "portfolio bold immersive experimental typography",
 )
+CATEGORY_DOMAINS = {
+    "structure": ("landing", "style", "product", "ux"),
+    "typography": ("typography", "style", "ux"),
+    "color": ("color", "style", "ux"),
+    "media": ("style", "product", "landing", "ux"),
+    "primary_motion": ("motion", "style", "landing", "ux"),
+    "secondary_motion": ("motion", "react", "ux"),
+}
+DOMAIN_ID_KEYS = {
+    "landing": "Pattern Name",
+    "style": "Style Category",
+    "product": "Product Type",
+    "typography": "Font Pairing Name",
+    "color": "Product Type",
+    "motion": "Category",
+    "react": "Guideline",
+    "ux": "Issue",
+}
 WORD_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9+.#-]{1,30}")
 _VENDOR_CORE: ModuleType | None = None
+
+
+class DesignCatalogInsufficient(RuntimeError):
+    """Raised when a bounded catalog query cannot supply two candidates."""
 
 
 def _load_vendor_core() -> ModuleType:
@@ -135,6 +157,19 @@ def _search(domain: str, query: str, count: int = 8) -> list[dict[str, str]]:
     if "error" in result:
         raise RuntimeError(_string(result["error"]))
     return [dict(item) for item in result.get("results", [])]
+
+
+def _search_logical_domain(
+    domain: str, query: str, count: int = 8
+) -> list[dict[str, str]]:
+    if domain == "motion":
+        return _search("gsap", query, count)
+    if domain == "react":
+        result = _load_vendor_core().search_stack(query, "react", count)
+        if "error" in result:
+            raise RuntimeError(_string(result["error"]))
+        return [dict(item) for item in result.get("results", [])]
+    return _search(domain, query, count)
 
 
 def _source_id(domain: str, row: Mapping[str, object], key: str) -> str:
@@ -280,6 +315,192 @@ def recommend(content_map: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _approved_decision_ids(decisions: Mapping[str, object]) -> list[str]:
+    result: list[str] = []
+    for category in CATEGORY_DOMAINS:
+        decision = _mapping(decisions.get(category))
+        approval = _mapping(decision.get("approval"))
+        if approval.get("status") != "user_approved":
+            continue
+        result.extend(
+            _string(item)
+            for item in _sequence(decision.get("selected_candidate_ids"))
+            if _string(item)
+        )
+    return result
+
+
+def _category_query_context(
+    content_map: Mapping[str, object],
+    baseline: Mapping[str, object],
+    decisions: Mapping[str, object],
+) -> dict[str, object]:
+    profile = _content_profile(content_map)
+    return {
+        **profile,
+        "baseline_direction_id": _string(baseline.get("selected_direction_id")),
+        "approved_decision_ids": _approved_decision_ids(decisions),
+    }
+
+
+def build_baseline(
+    content_map: Mapping[str, object],
+    reference_selection: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    report = recommend(content_map)
+    report["mode"] = "baseline"
+    report["report_type"] = "baseline"
+    report["reference_selection_ids"] = _unique_tokens(
+        _safe_tokens(reference_selection or {}), limit=8
+    )
+    return report
+
+
+def _row_label(domain: str, row: Mapping[str, object]) -> str:
+    return _string(row.get(DOMAIN_ID_KEYS[domain]), domain)
+
+
+def _row_notes(row: Mapping[str, object]) -> list[str]:
+    keys = (
+        "Best For",
+        "Description",
+        "Do",
+        "Notes",
+        "Key Considerations",
+        "Effects & Animation",
+        "Mood/Style Keywords",
+        "Guideline",
+        "Performance Notes",
+    )
+    return [_string(row.get(key)) for key in keys if _string(row.get(key))]
+
+
+def _category_candidate(
+    category: str,
+    index: int,
+    rows: Mapping[str, Mapping[str, object]],
+    inherited_ids: Sequence[str],
+) -> dict[str, object]:
+    source_ids = [
+        _source_id(domain, row, DOMAIN_ID_KEYS[domain])
+        for domain, row in rows.items()
+        if row
+    ]
+    labels = [_row_label(domain, row) for domain, row in rows.items() if row]
+    notes = [note for row in rows.values() for note in _row_notes(row)]
+    accessibility = [
+        note
+        for note in notes
+        if any(
+            term in note.casefold()
+            for term in ("access", "contrast", "focus", "motion", "touch")
+        )
+    ][:3]
+    return {
+        "id": f"{category}-{index + 1}",
+        "label": " · ".join(labels[:2]),
+        "fit": notes[:2] or [f"Catalog fit for {category}"],
+        "risks": notes[2:4]
+        or ["Verify content fit and implementation cost"],
+        "tradeoffs": notes[4:6]
+        or ["Balance expression, readability, and cost"],
+        "compatibility": list(inherited_ids),
+        "responsive_fallback": (
+            "Preserve semantic order in a single-column document flow"
+        ),
+        "accessibility_notes": accessibility
+        or ["Verify focus, contrast, touch, and reduced-motion behavior"],
+        "source_ids": source_ids,
+    }
+
+
+def _category_candidates(
+    category: str,
+    query: str,
+    inherited_ids: Sequence[str],
+) -> list[dict[str, object]]:
+    domains = CATEGORY_DOMAINS[category]
+    rows_by_domain = {
+        domain: _search_logical_domain(domain, query, 8) for domain in domains
+    }
+    available = min((len(rows) for rows in rows_by_domain.values()), default=0)
+    return [
+        _category_candidate(
+            category,
+            index,
+            {domain: rows[index] for domain, rows in rows_by_domain.items()},
+            inherited_ids,
+        )
+        for index in range(min(available, 3))
+    ]
+
+
+def search_category(
+    category: str,
+    content_map: Mapping[str, object],
+    baseline: Mapping[str, object],
+    decisions: Mapping[str, object],
+) -> dict[str, object]:
+    if category not in CATEGORY_DOMAINS:
+        raise ValueError(f"unsupported design category: {category}")
+    if not isinstance(content_map, Mapping):
+        raise ValueError("content map must be a JSON object")
+    if not isinstance(baseline, Mapping):
+        raise ValueError("baseline must be a JSON object")
+    if not isinstance(decisions, Mapping):
+        raise ValueError("decisions must be a JSON object")
+
+    context = _category_query_context(content_map, baseline, decisions)
+    inherited_ids = list(context["approved_decision_ids"])
+    full_query = _query_text(
+        context,
+        " ".join(
+            [
+                category,
+                _string(context["baseline_direction_id"]),
+                *inherited_ids,
+            ]
+        ),
+    )
+    candidates = _category_candidates(category, full_query, inherited_ids)
+    if len(candidates) < 2:
+        broad_query = " ".join(
+            filter(
+                None,
+                (
+                    _string(context["role"]),
+                    _string(context["industry"]),
+                    _string(context["content_density"]),
+                    _string(context["media_profile"]),
+                    _string(context["baseline_direction_id"]),
+                    *inherited_ids,
+                    category,
+                ),
+            )
+        )
+        candidates = _category_candidates(category, broad_query, inherited_ids)
+    if len(candidates) < 2:
+        raise DesignCatalogInsufficient(
+            "design_catalog_insufficient: "
+            f"category={category}; domains={','.join(CATEGORY_DOMAINS[category])}; "
+            f"found={len(candidates)}; required=2"
+        )
+    return {
+        "schema_version": 1,
+        "report_type": "category",
+        "category": category,
+        "query_context": context,
+        "domains_searched": list(CATEGORY_DOMAINS[category]),
+        "inherited_decision_ids": inherited_ids,
+        "candidates": candidates,
+        "recommended_candidate_id": candidates[0]["id"],
+        "provenance": {
+            "upstream": UPSTREAM,
+            "catalog_version": validate_catalog(CATALOG_ROOT).catalog_version,
+        },
+    }
+
+
 def enrich(style_brief: Mapping[str, object], content_map: Mapping[str, object]) -> dict[str, object]:
     if not isinstance(style_brief, Mapping):
         raise ValueError("style brief must be a JSON object")
@@ -366,16 +587,48 @@ def main(argv: Sequence[str] | None = None) -> int:
     enrich_parser.add_argument("--input", type=Path, required=True)
     enrich_parser.add_argument("--content-map", type=Path, required=True)
     enrich_parser.add_argument("--output", type=Path, required=True)
+    baseline_parser = subparsers.add_parser("baseline")
+    baseline_parser.add_argument("--content-map", type=Path, required=True)
+    baseline_parser.add_argument("--reference-selection", type=Path)
+    baseline_parser.add_argument("--output", type=Path, required=True)
+    category_parser = subparsers.add_parser("category")
+    category_parser.add_argument(
+        "--category", choices=tuple(CATEGORY_DOMAINS), required=True
+    )
+    category_parser.add_argument("--content-map", type=Path, required=True)
+    category_parser.add_argument("--baseline", type=Path, required=True)
+    category_parser.add_argument("--decisions", type=Path, required=True)
+    category_parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "recommend":
             result = recommend(_read_json_object(args.input, "content map"))
-        else:
+        elif args.command == "enrich":
             result = enrich(
                 _read_json_object(args.input, "style brief"),
                 _read_json_object(args.content_map, "content map"),
             )
+        elif args.command == "baseline":
+            reference_selection = (
+                _read_json_object(args.reference_selection, "reference selection")
+                if args.reference_selection
+                else None
+            )
+            result = build_baseline(
+                _read_json_object(args.content_map, "content map"),
+                reference_selection,
+            )
+        else:
+            result = search_category(
+                args.category,
+                _read_json_object(args.content_map, "content map"),
+                _read_json_object(args.baseline, "baseline"),
+                _read_json_object(args.decisions, "decisions"),
+            )
         _atomic_write_json(args.output, result)
+    except DesignCatalogInsufficient as error:
+        print(str(error), file=sys.stderr)
+        return 3
     except ValueError as error:
         print(str(error), file=sys.stderr)
         return 2

--- a/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
@@ -16,7 +16,6 @@ EXPECTED_DOMAINS = {
     "secondary_motion": ["motion", "react", "ux"],
 }
 PRIVACY_SENSITIVE_KEYS = {
-    "name",
     "full_name",
     "email",
     "phone",
@@ -66,16 +65,18 @@ def _strings(value: Any, *, non_empty: bool = False) -> bool:
     )
 
 
-def _privacy_errors(value: Any) -> list[str]:
+def _privacy_errors(
+    value: Any, forbidden_keys: set[str] = PRIVACY_SENSITIVE_KEYS
+) -> list[str]:
     errors: list[str] = []
     if isinstance(value, dict):
         for key, child in value.items():
-            if str(key).strip().casefold() in PRIVACY_SENSITIVE_KEYS:
+            if str(key).strip().casefold() in forbidden_keys:
                 errors.append(f"privacy-sensitive key is not allowed: {key}")
-            errors.extend(_privacy_errors(child))
+            errors.extend(_privacy_errors(child, forbidden_keys))
     elif isinstance(value, list):
         for child in value:
-            errors.extend(_privacy_errors(child))
+            errors.extend(_privacy_errors(child, forbidden_keys))
     return errors
 
 
@@ -184,6 +185,10 @@ def validate(payload: Any, expected_type: str | None = None) -> list[str]:
     if expected_type is not None and report_type != expected_type:
         errors.append(f"expected report type: {expected_type}")
     errors.extend(_privacy_errors(payload))
+    query_payload = payload.get("query")
+    if query_payload is None:
+        query_payload = payload.get("query_context")
+    errors.extend(_privacy_errors(query_payload, {"name"}))
     if report_type == "baseline":
         errors.extend(_validate_baseline(payload))
     elif report_type == "category":

--- a/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_DOMAINS = {
+    "structure": ["landing", "style", "product", "ux"],
+    "typography": ["typography", "style", "ux"],
+    "color": ["color", "style", "ux"],
+    "media": ["style", "product", "landing", "ux"],
+    "primary_motion": ["motion", "style", "landing", "ux"],
+    "secondary_motion": ["motion", "react", "ux"],
+}
+PRIVACY_SENSITIVE_KEYS = {
+    "name",
+    "full_name",
+    "email",
+    "phone",
+    "telephone",
+    "address",
+    "location",
+    "wechat",
+    "weixin",
+    "qq",
+    "contact",
+    "contact_details",
+    "raw_resume",
+    "resume_text",
+    "project_secret",
+}
+BASELINE_DIRECTION_FIELDS = {
+    "id",
+    "name",
+    "style_family",
+    "composition",
+    "color_relationships",
+    "typography_roles",
+    "surface_language",
+    "media_strategy",
+    "fit_reasons",
+    "risks",
+    "source_ids",
+}
+CANDIDATE_LIST_FIELDS = (
+    "fit",
+    "risks",
+    "tradeoffs",
+    "accessibility_notes",
+    "source_ids",
+)
+
+
+def _string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _strings(value: Any, *, non_empty: bool = False) -> bool:
+    return (
+        isinstance(value, list)
+        and (bool(value) or not non_empty)
+        and all(_string(item) for item in value)
+    )
+
+
+def _privacy_errors(value: Any) -> list[str]:
+    errors: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).strip().casefold() in PRIVACY_SENSITIVE_KEYS:
+                errors.append(f"privacy-sensitive key is not allowed: {key}")
+            errors.extend(_privacy_errors(child))
+    elif isinstance(value, list):
+        for child in value:
+            errors.extend(_privacy_errors(child))
+    return errors
+
+
+def _validate_provenance(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["provenance must be an object"]
+    errors: list[str] = []
+    for field in ("upstream", "catalog_version"):
+        if not _string(value.get(field)):
+            errors.append(f"provenance requires {field}")
+    return errors
+
+
+def _validate_baseline(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("mode") != "baseline":
+        errors.append("baseline mode must be baseline")
+    directions = payload.get("candidate_directions")
+    if not isinstance(directions, list) or len(directions) != 3:
+        errors.append("baseline requires exactly three directions")
+        directions = []
+    ids: list[str] = []
+    for index, direction in enumerate(directions):
+        if not isinstance(direction, dict):
+            errors.append(f"direction[{index}] must be an object")
+            continue
+        missing = BASELINE_DIRECTION_FIELDS - set(direction)
+        if missing:
+            errors.append(
+                f"direction[{index}] missing fields: {', '.join(sorted(missing))}"
+            )
+        direction_id = direction.get("id")
+        if _string(direction_id):
+            ids.append(direction_id)
+        else:
+            errors.append(f"direction[{index}] requires an ID")
+        if not _strings(direction.get("source_ids"), non_empty=True):
+            errors.append(f"direction {direction_id or index} requires source_ids")
+    if len(ids) != len(set(ids)):
+        errors.append("direction IDs must be unique")
+    if payload.get("selected_direction_id") not in ids:
+        errors.append("selected direction must reference a candidate")
+    errors.extend(_validate_provenance(payload.get("provenance")))
+    return errors
+
+
+def _validate_category(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    category = payload.get("category")
+    if category not in EXPECTED_DOMAINS:
+        return ["unsupported design category"]
+    if payload.get("domains_searched") != EXPECTED_DOMAINS[category]:
+        errors.append(f"{category} domains do not match contract")
+
+    inherited = payload.get("inherited_decision_ids")
+    context = payload.get("query_context")
+    if not isinstance(context, dict) or inherited != context.get(
+        "approved_decision_ids"
+    ):
+        errors.append("inherited decisions do not match query context")
+    if not _strings(inherited):
+        errors.append("inherited_decision_ids must be a string list")
+
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) < 2:
+        errors.append("category requires at least two candidates")
+        candidates = []
+    ids: list[str] = []
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            errors.append("candidate must be an object")
+            continue
+        candidate_id = candidate.get("id")
+        if not _string(candidate_id):
+            errors.append(f"candidate[{index}] requires an ID")
+            candidate_id = str(index)
+        else:
+            ids.append(candidate_id)
+        if not _string(candidate.get("label")):
+            errors.append(f"candidate {candidate_id} requires a label")
+        for field in CANDIDATE_LIST_FIELDS:
+            if not _strings(candidate.get(field), non_empty=True):
+                if field == "source_ids":
+                    errors.append(f"candidate {candidate_id} requires source_ids")
+                else:
+                    errors.append(f"candidate {candidate_id} requires {field}")
+        if not _strings(candidate.get("compatibility")):
+            errors.append(f"candidate {candidate_id} compatibility must be a string list")
+        if not _string(candidate.get("responsive_fallback")):
+            errors.append(f"candidate {candidate_id} requires responsive_fallback")
+    if len(ids) != len(set(ids)):
+        errors.append("candidate IDs must be unique")
+    if payload.get("recommended_candidate_id") not in ids:
+        errors.append("recommendation must reference a candidate")
+    errors.extend(_validate_provenance(payload.get("provenance")))
+    return errors
+
+
+def validate(payload: Any, expected_type: str | None = None) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["design discovery report must be an object"]
+    errors: list[str] = []
+    if payload.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    report_type = payload.get("report_type")
+    if expected_type is not None and report_type != expected_type:
+        errors.append(f"expected report type: {expected_type}")
+    errors.extend(_privacy_errors(payload))
+    if report_type == "baseline":
+        errors.extend(_validate_baseline(payload))
+    elif report_type == "category":
+        errors.extend(_validate_category(payload))
+    else:
+        errors.append("report_type must be baseline or category")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a database-first design discovery report."
+    )
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--expected-type", choices=("baseline", "category"))
+    args = parser.parse_args()
+    try:
+        payload = json.loads(args.report.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        print(f"ERROR: could not read design discovery report: {error}")
+        return 1
+    errors = validate(payload, expected_type=args.expected_type)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("OK: design discovery report is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_site_design_spec.py
@@ -123,16 +123,33 @@ def _validate_candidates(candidates: Any, category: str) -> tuple[list[str], lis
             continue
         candidate_id = candidate.get("id")
         label = candidate.get("label")
-        tradeoffs = candidate.get("tradeoffs")
         if not isinstance(candidate_id, str) or not candidate_id.strip():
             errors.append(f"{category} candidate[{index}] requires an ID")
             continue
         ids.append(candidate_id)
         if not isinstance(label, str) or not label.strip():
             errors.append(f"{category} candidate[{index}] requires a label")
-        if not _strings(tradeoffs, non_empty=True):
+        for field in (
+            "fit",
+            "risks",
+            "tradeoffs",
+            "accessibility_notes",
+            "source_ids",
+        ):
+            if not _strings(candidate.get(field), non_empty=True):
+                errors.append(
+                    f"{category} candidate[{index}] requires {field}"
+                )
+        if not _strings(candidate.get("compatibility")):
             errors.append(
-                f"{category} candidate[{index}] requires tradeoffs"
+                f"{category} candidate[{index}] compatibility must be a string list"
+            )
+        if (
+            not isinstance(candidate.get("responsive_fallback"), str)
+            or not candidate["responsive_fallback"].strip()
+        ):
+            errors.append(
+                f"{category} candidate[{index}] requires responsive_fallback"
             )
     if len(ids) != len(set(ids)):
         errors.append(f"{category} candidate IDs must be unique")
@@ -150,6 +167,19 @@ def _validate_confirmed_decision(
     candidate_ids, errors = _validate_candidates(
         decision.get("candidates"), category
     )
+    expected_report = (
+        ".resume-site-work/reports/design-discovery/"
+        f"{category.replace('_', '-')}.json"
+    )
+    discovery_report = str(decision.get("discovery_report") or "").replace(
+        "\\", "/"
+    )
+    if not discovery_report:
+        errors.append(f"{category} requires a discovery report")
+    elif discovery_report != expected_report:
+        errors.append(
+            f"{category} discovery report must be {expected_report}"
+        )
     known = set(candidate_ids)
     if decision.get("recommended_candidate_id") not in known:
         errors.append(f"{category} recommendation must reference a candidate")
@@ -173,10 +203,12 @@ def _validate_confirmed_decision(
 
 def _validate_media_decision(decision: Any) -> list[str]:
     if isinstance(decision, dict) and decision.get("status") == "skipped":
+        errors: list[str] = []
         reason = decision.get("skip_reason")
         if not isinstance(reason, str) or not reason.strip():
-            return ["media skip requires a reason"]
-        return []
+            errors.append("media skip requires a reason")
+        errors.extend(_validate_approval(decision.get("approval"), "media"))
+        return errors
     return _validate_confirmed_decision(
         "media", decision, allow_multiple=False
     )

--- a/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
@@ -97,6 +97,7 @@ STAGE_RESOURCES = {
         "site-design-spec-schema",
         "visual-style-preview-contract",
         "visual-companion",
+        "design-catalog",
     ),
     "planning": (
         "site-planning-contract",

--- a/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
@@ -90,6 +90,12 @@ CONTENT_WORKFLOW_FILES = (
     "scripts/write_resume_site_input.py",
 )
 
+DESIGN_DISCOVERY_FILES = (
+    "references/design-discovery-schema.json",
+    "scripts/validate_design_discovery.py",
+    "scripts/portfolio_design_search.py",
+)
+
 STAGE_RESOURCES = {
     "content-preparation": ("content-workflow",),
     "discovery": (
@@ -98,6 +104,7 @@ STAGE_RESOURCES = {
         "visual-style-preview-contract",
         "visual-companion",
         "design-catalog",
+        "design-discovery",
     ),
     "planning": (
         "site-planning-contract",
@@ -106,6 +113,7 @@ STAGE_RESOURCES = {
     "integrated": (
         "generate-integrated-site",
         "design-catalog",
+        "design-discovery",
         "aesthetic-quality-loop",
         "audit-screenshot",
         "repair-local-issues",
@@ -288,6 +296,7 @@ def validate_resources(skill_root: Path, mode: str, stage: str | None, workspace
             "visual-companion",
             "aesthetic-quality-loop",
             "content-workflow",
+            "design-discovery",
         )
         if mode == "skeleton"
         else STAGE_RESOURCES[stage]
@@ -358,6 +367,32 @@ def validate_resources(skill_root: Path, mode: str, stage: str | None, workspace
                 except (OSError, UnicodeError, json.JSONDecodeError) as error:
                     resource_errors.append(
                         f"invalid_content_workflow_file: {relative}: {error}"
+                    )
+            resource_ready = not resource_errors
+        elif resource_id == "design-discovery":
+            resource_errors = []
+            for relative in DESIGN_DISCOVERY_FILES:
+                path = skill_root / relative
+                if not path.is_file():
+                    resource_errors.append(
+                        f"missing_design_discovery_file: {relative}"
+                    )
+                    continue
+                try:
+                    text = path.read_text(encoding="utf-8").strip()
+                    if not text:
+                        resource_errors.append(
+                            f"empty_design_discovery_file: {relative}"
+                        )
+                    elif path.suffix == ".json" and not isinstance(
+                        json.loads(text), dict
+                    ):
+                        resource_errors.append(
+                            f"invalid_design_discovery_file: {relative}"
+                        )
+                except (OSError, UnicodeError, json.JSONDecodeError) as error:
+                    resource_errors.append(
+                        f"invalid_design_discovery_file: {relative}: {error}"
                     )
             resource_ready = not resource_errors
         else:


### PR DESCRIPTION
## 变更内容

- 在第一次视觉提问前生成数据库设计 baseline。
- 让结构、字体、配色、媒体、主动效和副动效逐项查询本地 UI/UX 数据库。
- 后续分类查询继承前序已批准候选，并保留数据库来源 ID。
- 新增设计发现报告 schema、验证器、聚合接口和 CLI。
- 将批准后的六项发现聚合为生成阶段的固定输入，移除晚期通用推荐。
- 将数据库证据绑定到最终站点设计规格，并注册完整运行资源。
- 保留最新 `master` 的内容质量门禁，质量验证通过后才进入设计 baseline。

## 重建原因

PR #9 基于过旧的共同基点，和后来合并的仓库精简、内容工作流与内容质量门禁产生大量 add/add、modify/delete 和内容冲突。本 PR 从最新 `origin/master` 重建，只迁移生产实现，不重新加入主线已删除的测试、旧发布文件或历史重复提交。

主动效查询曾因逻辑分类词与 `motion.csv` 的可检索词不一致而返回空结果；适配器现在使用数据库原生的 scroll、reveal、hover、stagger 等词汇检索，同时继续在候选不足时明确失败，不伪造候选。

## 验证

- 旧分支相关回归套件：44/44 通过
- Skill quick validation：通过
- skeleton 资源完整性校验：通过
- discovery 运行资源校验：通过
- integrated 运行资源校验：通过
- Python/JSON 语法校验：通过
- Node CJS 语法检查：3/3 通过
- 生产范围与平台合规扫描：通过
- `git merge-tree --write-tree origin/master HEAD`：无冲突

替代有冲突的 PR #9。
