### PR TITLE
feat: 在视觉选择前建立反模板设计基线

### DIFF
--- a/docs/superpowers/plans/2026-08-14-early-anti-template-baseline.md
+++ b/docs/superpowers/plans/2026-08-14-early-anti-template-baseline.md
@@ -1,0 +1,261 @@
+# Early Anti-Template Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate and validate a provisional anti-template baseline before the first visual choice, then require all six category searches and final aggregation to trace back to it.
+
+**Architecture:** Extend the existing database-first discovery protocol with a third report type, `anti_template_baseline`. The same dependency-free Python CLI produces it from the validated content/database baseline, category reports evaluate candidates against its obligations, and approved-discovery aggregation carries it forward so final creative-direction compilation can resolve provisional hypotheses into approved commitments.
+
+**Tech Stack:** Python 3 standard library, JSON Schema documentation, existing vendored UI/UX catalog, `unittest`, Markdown Skill contracts.
+
+## Global Constraints
+
+- Keep runtime dependency-free and offline after installation.
+- The provisional artifact is not user approval and cannot authorize React source edits.
+- Every anti-template claim must trace to content, reference, or catalog evidence.
+- Each category query must inherit the provisional baseline and all previously approved decision IDs.
+- Final `creative-direction.json` and `design-contract.json` remain authoritative only after final requirements approval.
+- Existing confirmed sites and bounded fast changes remain valid; incomplete legacy discovery must regenerate from baseline.
+
+---
+
+### Task 1: Produce and validate the provisional anti-template baseline
+
+**Files:**
+- Create: `skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/portfolio_design_search.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_design_discovery.py`
+- Modify: `skills/build-resume-portfolio-site/references/design-discovery-schema.json`
+
+**Interfaces:**
+- Consumes: `build_baseline(content_map, reference_selection)` output.
+- Produces: `build_anti_template_baseline(content_map, baseline) -> dict[str, object]` and CLI command `anti-template-baseline --content-map PATH --baseline PATH --output PATH`.
+- Produces report fields: `schema_version`, stable `id`, `report_type`, `mode`, `status`, `query_context`, `evidence_ids`, `visual_protagonist`, `content_form_thesis`, `composition_hypothesis`, `signature_device_candidates`, `template_independence_claim`, `anti_template_rules`, `category_obligations`, and `provenance`.
+
+- [ ] **Step 1: Write failing producer and validator tests**
+
+Create `test_early_anti_template_baseline.py` with a small content map and validated database baseline. Assert:
+
+```python
+report = search.build_anti_template_baseline(content_map, baseline)
+self.assertEqual(report["report_type"], "anti_template_baseline")
+self.assertEqual(report["status"], "provisional_unapproved")
+self.assertTrue(report["evidence_ids"])
+self.assertEqual(set(report["category_obligations"]), set(search.CATEGORY_DOMAINS))
+self.assertEqual(validate.validate(report, "anti_template_baseline"), [])
+
+invalid = copy.deepcopy(report)
+invalid["evidence_ids"] = []
+self.assertIn(
+    "anti-template baseline requires evidence_ids",
+    validate.validate(invalid, "anti_template_baseline"),
+)
+```
+
+Load both scripts with `importlib.util.spec_from_file_location`, matching the repository's standalone-script layout, and patch catalog validation only where a test must avoid reading unrelated files.
+
+- [ ] **Step 2: Run the focused test and verify red state**
+
+Run:
+
+```powershell
+python -m unittest skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py -v
+```
+
+Expected: FAIL because `build_anti_template_baseline` and the report type do not exist.
+
+- [ ] **Step 3: Implement the minimal baseline builder and CLI command**
+
+In `portfolio_design_search.py`, derive evidence only from baseline candidates, reference IDs, content-map field-path IDs such as `content-map:profile.role`, and catalog source IDs. Use stable IDs and explicit project-context language:
+
+```python
+def build_anti_template_baseline(content_map, baseline):
+    errors = validate_discovery_report(baseline, expected_type="baseline")
+    if errors:
+        raise ValueError("baseline design discovery report is invalid")
+    selected = next(
+        item for item in _sequence(baseline["candidate_directions"])
+        if _mapping(item).get("id") == baseline["selected_direction_id"]
+    )
+    # Build evidence-linked provisional hypotheses and one obligation per
+    # CATEGORY_DOMAINS entry; never mark a choice user-approved.
+```
+
+Add the CLI parser and branch so the output uses the existing atomic writer.
+
+- [ ] **Step 4: Extend deterministic validation and schema documentation**
+
+Add `_validate_anti_template_baseline()` requiring non-empty evidence, thesis fields, at least one signature candidate and rule, exactly six obligation keys, `status == "provisional_unapproved"`, and valid provenance. Extend `--expected-type` choices and error text to include the new report type. Mirror those requirements in `design-discovery-schema.json` with a third `oneOf` branch.
+
+- [ ] **Step 5: Run focused and syntax checks**
+
+Run:
+
+```powershell
+python -m unittest skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py -v
+python -m py_compile skills/build-resume-portfolio-site/scripts/portfolio_design_search.py skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
+```
+
+Expected: all tests PASS and both scripts compile without output.
+
+- [ ] **Step 6: Commit Task 1**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py skills/build-resume-portfolio-site/scripts/portfolio_design_search.py skills/build-resume-portfolio-site/scripts/validate_design_discovery.py skills/build-resume-portfolio-site/references/design-discovery-schema.json
+git commit -m "feat: generate early anti-template baseline"
+```
+
+### Task 2: Require anti-template inheritance in category search and aggregation
+
+**Files:**
+- Modify: `skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/portfolio_design_search.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_design_discovery.py`
+- Modify: `skills/build-resume-portfolio-site/references/design-discovery-schema.json`
+- Modify: `skills/build-resume-portfolio-site/references/design-intelligence-schema.json`
+- Modify: `skills/build-resume-portfolio-site/references/design-intelligence-contract.md`
+
+**Interfaces:**
+- Changes `search_category(category, content_map, baseline, anti_template_baseline, decisions)`.
+- Changes `aggregate_discovery(content_map, baseline, anti_template_baseline, category_reports, design_spec)`.
+- Category candidates produce `anti_template_evaluation` with `baseline_rule_ids`, `obligation_ids`, `relationship`, and `rationale`.
+- Approved-discovery aggregate produces `anti_template_baseline` and `anti_template_resolution_required: true`.
+
+- [ ] **Step 1: Write failing inheritance tests**
+
+Add tests that patch `_category_candidates` with two deterministic candidates and assert:
+
+```python
+report = search.search_category(
+    "structure", content_map, baseline, anti_template_baseline, decisions
+)
+self.assertEqual(
+    report["anti_template_baseline_id"], anti_template_baseline["id"]
+)
+self.assertTrue(report["candidates"][0]["anti_template_evaluation"]["baseline_rule_ids"])
+self.assertEqual(validate.validate(report, "category"), [])
+```
+
+Add negative cases for a missing baseline ID, an unknown rule ID, absent category obligation, and a candidate whose evaluation relationship is outside `strengthens`, `preserves`, or `conflicts`.
+
+- [ ] **Step 2: Run focused tests and verify red state**
+
+Run the same unittest command. Expected: FAIL because function signatures and evaluation fields are unchanged.
+
+- [ ] **Step 3: Thread the baseline through category search**
+
+Add `--anti-template-baseline` to the category CLI. Validate it before querying. Include its thesis terms in query context, attach the report ID, and generate deterministic evaluations tied to the current category obligation. Keep `conflicts` eligible for presentation but never as the default recommendation; select the first `strengthens` candidate, then `preserves`, and fail if every candidate conflicts.
+
+- [ ] **Step 4: Validate category traceability**
+
+Require the baseline report ID at report level. For every candidate, require non-empty known `baseline_rule_ids`, the current category's obligation ID, allowed relationship enum, and rationale. Update the category schema accordingly.
+
+- [ ] **Step 5: Enforce aggregation continuity**
+
+Add `--anti-template-baseline` to aggregate CLI. Validate it, verify every category report references the same ID, and return:
+
+```python
+{
+    "anti_template_baseline": dict(anti_template_baseline),
+    "anti_template_resolution_required": True,
+}
+```
+
+Require these fields in approved-discovery mode in `design-intelligence-schema.json` and explain that creative direction must resolve every provisional rule as `adopted`, `refined`, or `rejected_by_approved_choice`, with evidence.
+
+- [ ] **Step 6: Run focused tests and existing resource validation**
+
+Run:
+
+```powershell
+python -m unittest skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py -v
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage discovery
+```
+
+Expected: PASS and `OK` resource validation.
+
+- [ ] **Step 7: Commit Task 2**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py skills/build-resume-portfolio-site/scripts/portfolio_design_search.py skills/build-resume-portfolio-site/scripts/validate_design_discovery.py skills/build-resume-portfolio-site/references/design-discovery-schema.json skills/build-resume-portfolio-site/references/design-intelligence-schema.json skills/build-resume-portfolio-site/references/design-intelligence-contract.md
+git commit -m "feat: trace visual choices to anti-template baseline"
+```
+
+### Task 3: Move the workflow gate before the first visual choice
+
+**Files:**
+- Modify: `skills/build-resume-portfolio-site/SKILL.md`
+- Modify: `skills/build-resume-portfolio-site/references/workflow-contract.md`
+- Modify: `skills/build-resume-portfolio-site/references/site-brainstorming-contract.md`
+- Modify: `skills/build-resume-portfolio-site/references/artifact-layout.md`
+- Modify: `skills/build-resume-portfolio-site/references/creative-direction-contract.md`
+- Modify: `skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md`
+- Modify: `skills/build-resume-portfolio-site/scripts/validate_skill_resources.py`
+- Modify: `skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py`
+
+**Interfaces:**
+- Adds workflow stages `anti_template_baseline_generating` and `anti_template_baseline_ready` between `design_baseline_ready` and the structure query.
+- Adds canonical artifact `reports/design-discovery/anti-template-baseline.json`.
+- Final creative direction consumes the aggregate's provisional baseline and resolves it without reopening approved category choices.
+
+- [ ] **Step 1: Write failing workflow-contract assertions**
+
+Add tests that read `SKILL.md` and contracts and require:
+
+```python
+self.assertLess(skill.index("anti_template_baseline_generating"), skill.index("--category structure"))
+self.assertIn('anti-template-baseline.json" `\n  --expected-type anti_template_baseline', skill)
+self.assertIn("--anti-template-baseline", skill)
+self.assertIn("provisional_unapproved", creative_direction_contract)
+```
+
+Also assert the Skill explicitly says browser preview and user choice remain per-category approvals, while the provisional baseline is not approval.
+
+- [ ] **Step 2: Run focused tests and verify red state**
+
+Run the focused unittest command. Expected: FAIL because the workflow still jumps directly from database baseline to category search.
+
+- [ ] **Step 3: Update Skill commands and ordering**
+
+In `SKILL.md`, insert the generation and validation commands immediately after `design_baseline_ready`:
+
+```powershell
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" anti-template-baseline `
+  --content-map ".resume-site-work\reports\content-map.json" `
+  --baseline ".resume-site-work\reports\design-discovery\baseline.json" `
+  --output ".resume-site-work\reports\design-discovery\anti-template-baseline.json"
+python "$SKILL_ROOT\scripts\validate_design_discovery.py" `
+  ".resume-site-work\reports\design-discovery\anti-template-baseline.json" `
+  --expected-type anti_template_baseline
+```
+
+Pass `--anti-template-baseline` to all six category commands and aggregate. State that the artifact constrains candidate evaluation but adds no user approval gate.
+
+- [ ] **Step 4: Update contracts and artifact layout**
+
+Document stage transitions, invalidation behavior, artifact paths, category evaluation, legacy in-progress regeneration, and final creative-direction resolution. Do not add a new confirmation step or change final screenshot audit behavior.
+
+- [ ] **Step 5: Register resources and run full verification**
+
+Run:
+
+```powershell
+python -m unittest skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py -v
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage discovery
+python skills/build-resume-portfolio-site/scripts/validate_skill_resources.py --mode runtime --stage integrated
+python -m compileall -q skills/build-resume-portfolio-site/scripts
+git diff --check
+```
+
+Expected: all tests PASS, both resource stages report `OK`, Python compilation succeeds, and `git diff --check` is silent.
+
+- [ ] **Step 6: Sync and compare the installed Skill**
+
+After source verification, replace only `C:\Users\86135\.codex\skills\build-resume-portfolio-site` from the verified repository Skill directory, then compare recursive file hashes. Do not copy repository docs or Git metadata into the installed Skill.
+
+- [ ] **Step 7: Commit Task 3**
+
+```powershell
+git add -- skills/build-resume-portfolio-site/SKILL.md skills/build-resume-portfolio-site/references/workflow-contract.md skills/build-resume-portfolio-site/references/site-brainstorming-contract.md skills/build-resume-portfolio-site/references/artifact-layout.md skills/build-resume-portfolio-site/references/creative-direction-contract.md skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md skills/build-resume-portfolio-site/scripts/validate_skill_resources.py skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
+git commit -m "feat: require anti-template baseline before visual choices"
+```

--- a/docs/superpowers/specs/2026-08-14-early-anti-template-baseline-design.md
+++ b/docs/superpowers/specs/2026-08-14-early-anti-template-baseline-design.md
@@ -1,0 +1,89 @@
+# Early Anti-Template Baseline Design
+
+## Goal
+
+Move anti-template reasoning ahead of the six visual decisions without turning
+unapproved recommendations into a final design contract.
+
+## Chosen approach
+
+Use a two-stage contract model:
+
+1. After the database baseline is validated and before the structure question,
+   generate a provisional anti-template baseline from approved content,
+   reference evidence, and catalog evidence.
+2. After all six decisions and final requirements approval, compile the existing
+   `creative-direction.json` and `design-contract.json` as the authoritative
+   implementation contract.
+
+The provisional artifact constrains discovery but never approves a category,
+replaces the user's choice, or authorizes source generation.
+
+## Provisional artifact
+
+Add `reports/design-discovery/anti-template-baseline.json`. It must contain:
+
+- content and catalog evidence IDs;
+- the candidate visual protagonist;
+- the content-to-form thesis;
+- the recommended composition hypothesis;
+- one or more candidate signature structural devices;
+- a template-independence claim;
+- project-specific anti-template rules;
+- category obligations describing what each of the six later searches must
+  preserve, test, or avoid;
+- status showing that the artifact is provisional and unapproved.
+
+Every claim must trace to content, reference, or catalog evidence. Missing
+evidence blocks presentation instead of allowing a generic direction.
+
+## Discovery flow
+
+The flow becomes:
+
+`content map -> database baseline -> provisional anti-template baseline -> six
+sequential category searches -> final requirements approval -> final creative
+direction -> final design contract -> React generation`.
+
+Every category search receives the provisional baseline plus all previously
+approved decisions. Its candidates must report whether they strengthen,
+preserve, or conflict with the visual protagonist, content-to-form thesis,
+signature device, and anti-template rules. Conflicting candidates may be shown
+only when clearly labeled as a trade-off; they cannot be recommended silently.
+
+The working decision file accumulates the effect of each approved choice. This
+is decision evidence, not a second source of truth. Reversing an earlier core
+choice invalidates downstream decisions as it does today.
+
+## Final compilation
+
+Aggregation must consume the validated provisional baseline and six validated
+category reports. `creative-direction.json` turns the provisional hypotheses
+into approved commitments or records how an approved choice changed them.
+`design-contract.json` remains the only authoritative observable contract for
+implementation and screenshot audit.
+
+No React source may be edited from the provisional artifact alone.
+
+## Validation and compatibility
+
+- Extend the design-discovery schema and validator with an
+  `anti_template_baseline` report type.
+- Require every category report to trace its anti-template evaluation to the
+  provisional baseline.
+- Require aggregation to fail when the baseline is missing, invalid, or not
+  represented in the final creative direction.
+- Preserve schema-version compatibility for existing work: an in-progress
+  discovery created before this change must regenerate discovery from the
+  database baseline; confirmed sites and bounded fast changes remain valid.
+- Add positive and negative tests for ordering, evidence traceability,
+  category inheritance, aggregation, and the prohibition on treating the
+  provisional artifact as approval.
+
+## Non-goals
+
+- No image-embedding or external template-library similarity service.
+- No blanket ban on cards, gradients, rounded corners, or common layout tools.
+- No additional user approval gate before the existing six questions.
+- No change to the final screenshot audit and bounded repair loop beyond using
+  the stronger final contract it receives.

--- a/skills/build-resume-portfolio-site/SKILL.md
+++ b/skills/build-resume-portfolio-site/SKILL.md
@@ -135,17 +135,36 @@ python "$SKILL_ROOT\scripts\validate_design_discovery.py" `
    If a reference selection exists, also pass `--reference-selection`. On
    success set `stage=design_baseline_ready`; on catalog insufficiency stop and
    report the exact missing evidence instead of inventing a direction.
-4. Initialize `reports/design-decisions-working.json`. Before presenting each
-   category, run the matching query below. Every later query reads all prior
-   conversationally approved IDs through `inherited_decision_ids`:
+4. Before the structure question, set
+   `stage=anti_template_baseline_generating`, compile the database baseline into
+   a provisional project-specific visual thesis, and validate it:
 
 ```powershell
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category structure --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\structure.json"
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category typography --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\typography.json"
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category color --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\color.json"
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category media --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\media.json"
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category primary_motion --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\primary-motion.json"
-python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category secondary_motion --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\secondary-motion.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" anti-template-baseline `
+  --content-map ".resume-site-work\reports\content-map.json" `
+  --baseline ".resume-site-work\reports\design-discovery\baseline.json" `
+  --output ".resume-site-work\reports\design-discovery\anti-template-baseline.json"
+python "$SKILL_ROOT\scripts\validate_design_discovery.py" `
+  ".resume-site-work\reports\design-discovery\anti-template-baseline.json" `
+  --expected-type anti_template_baseline
+```
+
+   On success set `stage=anti_template_baseline_ready`. This provisional
+   artifact does not select any of the six categories or authorize React source
+   edits. The provisional baseline is not approval.
+   Browser preview and user choice remain per-category approvals.
+5. Initialize `reports/design-decisions-working.json`. Before presenting each
+   category, run the matching query below. Every later query reads all prior
+   conversationally approved IDs through `inherited_decision_ids`, and every
+   query evaluates candidates against the same anti-template baseline:
+
+```powershell
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category structure --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\structure.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category typography --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\typography.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category color --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\color.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category media --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\media.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category primary_motion --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\primary-motion.json"
+python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category secondary_motion --content-map ".resume-site-work\reports\content-map.json" --baseline ".resume-site-work\reports\design-discovery\baseline.json" --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" --decisions ".resume-site-work\reports\design-decisions-working.json" --output ".resume-site-work\reports\design-discovery\secondary-motion.json"
 ```
 
    These are six sequential transactions, not one batch: run only the current
@@ -154,29 +173,29 @@ python "$SKILL_ROOT\scripts\portfolio_design_search.py" category --category seco
    persist the approved selection before running the next command. A report
    without non-empty `source_ids`, or with fewer than two candidates, cannot be
    presented as database output.
-5. Ask one question at a time and complete these categories in exact order:
+6. Ask one question at a time and complete these categories in exact order:
    overall structure, typography, color system, conditional media treatment,
    primary motion, and secondary motion.
-6. For every enabled category, compare candidates and recommend one with fit,
+7. For every enabled category, compare candidates and recommend one with fit,
    risk, and trade-offs. Then separately ask whether to open the browser
    comparison before requesting the user's choice.
-7. On acceptance, follow `visual-style-preview-contract.md`, create an
+8. On acceptance, follow `visual-style-preview-contract.md`, create an
    independent display-only `gallery.html`, run `launch.cjs --open`, and give
    the user the complete authenticated URL plus the absolute static HTML fallback.
    On decline, record the decline and continue text-only. Previous
    consent never applies to the next category.
-8. After the preview or decline, receive the user's selection and final category
+9. After the preview or decline, receive the user's selection and final category
    confirmation in the conversation. Approval remains in the conversation:
    browser visits, reloads, screenshots, and launch events do not select,
    approve, or advance state.
-9. Media may be skipped only with an explicit reason and conversational
+10. Media may be skipped only with an explicit reason and conversational
    approval. Select exactly one
    primary-motion system. Secondary motion may contain multiple compatible
    effects without a fixed numeric cap.
-10. Summarize all decisions and mandatory responsive, accessibility,
+11. Summarize all decisions and mandatory responsive, accessibility,
    coarse-pointer, fallback, and reduced-motion constraints. Obtain final
    requirements confirmation.
-11. Write schema-version-3
+12. Write schema-version-3
    `.resume-site-work/reports/site-design-spec.json` and validate it:
 
 ```powershell
@@ -242,23 +261,27 @@ integration, preview promotion, snapshots, and publication.
 
 1. Validate `integrated` resources and set `stage=design_contract_compiling`.
 2. Read `prompts/01-generate-integrated-site.md`.
-3. Reuse the discovery-stage `reports/content-map.json`, validated baseline,
-   six category reports, and approved site design spec. Compile them before
-   React generation:
+3. Reuse the discovery-stage `reports/content-map.json`, validated database and
+   anti-template baselines, six category reports, and approved site design spec.
+   Compile them before React generation:
 
 ```powershell
 python "$SKILL_ROOT\scripts\portfolio_design_search.py" aggregate `
   --content-map ".resume-site-work\reports\content-map.json" `
   --baseline ".resume-site-work\reports\design-discovery\baseline.json" `
+  --anti-template-baseline ".resume-site-work\reports\design-discovery\anti-template-baseline.json" `
   --reports-dir ".resume-site-work\reports\design-discovery" `
   --site-design-spec ".resume-site-work\reports\site-design-spec.json" `
   --output ".resume-site-work\reports\design-intelligence.json"
 ```
 
    The aggregate is fixed approved input, not a new recommendation. Do not rerun
-   generic catalog recommendation here. Translate its selected candidates into
-   `reports/creative-direction.json` and validate it; implementation may resolve
-   open details but cannot reopen or contradict user choices.
+   generic catalog recommendation here. Translate its selected candidates and
+   resolve each provisional anti-template rule into
+   `reports/creative-direction.json`; validate it. Implementation may resolve
+   open details but cannot reopen or contradict user choices. Pass the aggregate
+   through the creative-direction validator's `--design-intelligence` input so
+   every provisional rule has exactly one approved-evidence resolution.
 4. Compile the approved design specification, design intelligence, and creative
    direction into a temporary sibling for `reports/design-contract.json`. Follow
    `references/design-contract.md`, validate the temporary report, and atomically

--- a/skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md
+++ b/skills/build-resume-portfolio-site/prompts/01-generate-integrated-site.md
@@ -20,7 +20,10 @@ Read and preserve:
 - `reports/site-todo-plan.md` as the user-approved readable plan;
 - `reports/site-implementation-plan.json` schema version 2;
 - `reports/design-intelligence.json` in `approved-discovery` mode as the
-  database-backed baseline and fixed selected-candidate evidence;
+  database-backed baseline, provisional anti-template baseline, resolved
+  anti-template trace, and fixed selected-candidate evidence;
+- validated `reports/creative-direction.json` as the approved-choice
+  resolution of every provisional anti-template rule;
 - validated `reports/design-contract.json` as observable implementation and
   acceptance commitments;
 - `reports/media-inventory.json` when authorized media exists.
@@ -31,6 +34,9 @@ or treat an unselected candidate as implementation freedom. Open details inside
 the approved candidates remain implementation freedom only when they do not
 contradict the six confirmed decisions, responsive fallbacks, accessibility
 notes, or source-linked constraints.
+Do not treat `provisional_unapproved` as user approval. Implement only the
+anti-template commitments resolved through approved category evidence in the
+validated creative direction and final design contract.
 
 ## Integrated implementation
 

--- a/skills/build-resume-portfolio-site/references/artifact-layout.md
+++ b/skills/build-resume-portfolio-site/references/artifact-layout.md
@@ -40,6 +40,7 @@ Create all generated material under `.resume-site-work/` in the active user work
 |   |-- design-decisions-working.json # approved IDs accumulated during discovery
 |   |-- design-discovery/
 |   |   |-- baseline.json
+|   |   |-- anti-template-baseline.json # provisional thesis before structure choice
 |   |   |-- structure.json
 |   |   |-- typography.json
 |   |   |-- color.json
@@ -100,12 +101,17 @@ creative-direction report may translate the approved design spec into
 implementation detail but may not contradict it.
 
 `reports/design-discovery/baseline.json` records the three database-backed
-directions created before the first visual question. Each category report
-records its exact catalog domains, privacy-safe query context, inherited prior
-decision IDs, candidates, recommendation, and source IDs. The working decision
-file contains only approved candidate IDs and conversational approval metadata;
-it is the inheritance input for the next category and has no independent
-approval semantics.
+directions created before the first visual question.
+`reports/design-discovery/anti-template-baseline.json` is generated immediately
+afterward and before the structure question. It records evidence-linked,
+project-specific hypotheses and six category obligations with
+`status=provisional_unapproved`. It cannot select a category, replace
+conversation approval, or authorize React edits. Each category report records
+its exact catalog domains, privacy-safe query context, inherited prior decision
+IDs, anti-template evaluation, candidates, recommendation, and source IDs. The
+working decision file contains only approved candidate IDs and conversational
+approval metadata; it is the inheritance input for the next category and has
+no independent approval semantics.
 
 `reports/multi-agent-implementation.json` exists only when the user explicitly
 selects parallel multi-Agent implementation. It records the parallel-wave
@@ -127,6 +133,7 @@ Initialize `build-state.json` with this minimum shape:
   "discovery": {
     "design_discovery": {
       "baseline": "reports/design-discovery/baseline.json",
+      "anti_template_baseline": "reports/design-discovery/anti-template-baseline.json",
       "categories": {
         "structure": "reports/design-discovery/structure.json",
         "typography": "reports/design-discovery/typography.json",

--- a/skills/build-resume-portfolio-site/references/creative-direction-contract.md
+++ b/skills/build-resume-portfolio-site/references/creative-direction-contract.md
@@ -21,6 +21,12 @@ Create the report after the approved `site-design-spec.json` and
 `design-intelligence.json`, and before the first React source edit. Translate
 the approved website decision and normalized facts without contradicting its
 fixed constraints, selected family, or avoid rules.
+The approved-discovery input also contains a
+`provisional_unapproved` anti-template baseline. Resolve every provisional rule
+as `adopted`, `refined`, or `rejected_by_approved_choice`, citing the approved
+category candidate and evidence that justifies the resolution. This converts
+early hypotheses into final commitments; it does not reopen a choice or create
+another approval gate.
 Candidate vocabulary may include Kinetic Marquee, Horizontal Pan, Coverflow
 Carousel, Drag-to-Pan Grid, Sticky Stack, Split-Screen Scroll, Hover Image
 Trail, and Parallax Tilt Card, but the vocabulary is a search space rather than
@@ -30,7 +36,8 @@ Write `.resume-site-work/reports/creative-direction.json` and validate it:
 
 ```powershell
 python "$SKILL_ROOT\scripts\validate_creative_direction.py" `
-  ".resume-site-work\reports\creative-direction.json"
+  ".resume-site-work\reports\creative-direction.json" `
+  --design-intelligence ".resume-site-work\reports\design-intelligence.json"
 ```
 
 Continue only on exit `0`.
@@ -59,6 +66,7 @@ design contract must exist before the first React source edit.
 - `concept_prototype`: the first-version visual commitments.
 - responsive and motion freedoms.
 - observable `review_questions`.
+- anti-template baseline resolutions linked to approved category evidence.
 
 Fixed, open, and avoid entries must not overlap. Open entries describe intent
 and possibility, not pixel dimensions, exact grids, JSX, HTML, class names, or

--- a/skills/build-resume-portfolio-site/references/creative-direction-schema.json
+++ b/skills/build-resume-portfolio-site/references/creative-direction-schema.json
@@ -14,7 +14,8 @@
     "concept_prototype",
     "responsive_freedom",
     "motion_freedom",
-    "review_questions"
+    "review_questions",
+    "anti_template_resolutions"
   ],
   "properties": {
     "schema_version": {"const": 1},
@@ -125,6 +126,22 @@
       "minItems": 3,
       "items": {"type": "string", "minLength": 1},
       "uniqueItems": true
+    },
+    "anti_template_resolutions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "status", "approved_candidate_ids", "evidence_ids", "rationale"],
+        "properties": {
+          "rule_id": {"type": "string", "minLength": 1},
+          "status": {"enum": ["adopted", "refined", "rejected_by_approved_choice"]},
+          "approved_candidate_ids": {"$ref": "#/$defs/nonEmptyStringList"},
+          "evidence_ids": {"$ref": "#/$defs/nonEmptyStringList"},
+          "rationale": {"type": "string", "minLength": 1}
+        }
+      }
     }
   },
   "$defs": {

--- a/skills/build-resume-portfolio-site/references/design-contract.md
+++ b/skills/build-resume-portfolio-site/references/design-contract.md
@@ -42,10 +42,14 @@ the last valid preview and snapshot.
 - `motion` defines exactly one primary system plus compatible secondary effects,
   purpose, controller ownership, reduced motion, coarse pointer, and fallbacks.
 - `anti_template_rules` contains contextual, observable failure detectors.
+  Compile them from `creative-direction.anti_template_resolutions`; every
+  provisional rule must be adopted, refined, or explicitly rejected by an
+  approved choice before contract validation.
 - `acceptance_checks` keeps identity fit and aesthetic quality separate and also
   covers accessibility, responsive integrity, and runtime safety.
 - `traceability` links every design section to approved decision IDs and
-  creative-direction paths.
+  creative-direction paths, including the evidence for each anti-template
+  resolution.
 
 Every rule has a stable `rule_id`, criterion, required evidence IDs, and
 severity. Use exact tokens when they implement an approved or accessibility

--- a/skills/build-resume-portfolio-site/references/design-discovery-schema.json
+++ b/skills/build-resume-portfolio-site/references/design-discovery-schema.json
@@ -4,6 +4,7 @@
   "title": "Database-first portfolio design discovery report",
   "oneOf": [
     { "$ref": "#/$defs/baseline" },
+    { "$ref": "#/$defs/antiTemplateBaseline" },
     { "$ref": "#/$defs/categoryReport" }
   ],
   "$defs": {
@@ -128,6 +129,71 @@
         "guardrails": { "$ref": "#/$defs/stringList" },
         "react_guidelines": { "$ref": "#/$defs/stringList" },
         "reference_selection_ids": { "$ref": "#/$defs/stringList" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "antiTemplateRule": {
+      "type": "object",
+      "required": ["id", "criterion", "evidence_ids"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "criterion": { "$ref": "#/$defs/nonEmptyString" },
+        "evidence_ids": { "$ref": "#/$defs/nonEmptyStringList" }
+      },
+      "additionalProperties": false
+    },
+    "categoryObligation": {
+      "type": "object",
+      "required": ["id", "preserve", "avoid", "evidence_ids"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "preserve": { "$ref": "#/$defs/nonEmptyString" },
+        "avoid": { "$ref": "#/$defs/nonEmptyString" },
+        "evidence_ids": { "$ref": "#/$defs/nonEmptyStringList" }
+      },
+      "additionalProperties": false
+    },
+    "antiTemplateBaseline": {
+      "type": "object",
+      "required": [
+        "schema_version", "id", "report_type", "mode", "status",
+        "query_context", "evidence_ids", "visual_protagonist",
+        "content_form_thesis", "composition_hypothesis",
+        "signature_device_candidates", "template_independence_claim",
+        "anti_template_rules", "category_obligations", "provenance"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "report_type": { "const": "anti_template_baseline" },
+        "mode": { "const": "anti-template-baseline" },
+        "status": { "const": "provisional_unapproved" },
+        "query_context": { "$ref": "#/$defs/queryProfile" },
+        "evidence_ids": { "$ref": "#/$defs/nonEmptyStringList" },
+        "visual_protagonist": { "$ref": "#/$defs/nonEmptyString" },
+        "content_form_thesis": { "$ref": "#/$defs/nonEmptyString" },
+        "composition_hypothesis": { "$ref": "#/$defs/nonEmptyString" },
+        "signature_device_candidates": { "$ref": "#/$defs/nonEmptyStringList" },
+        "template_independence_claim": { "$ref": "#/$defs/nonEmptyString" },
+        "anti_template_rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/antiTemplateRule" }
+        },
+        "category_obligations": {
+          "type": "object",
+          "required": ["structure", "typography", "color", "media", "primary_motion", "secondary_motion"],
+          "properties": {
+            "structure": { "$ref": "#/$defs/categoryObligation" },
+            "typography": { "$ref": "#/$defs/categoryObligation" },
+            "color": { "$ref": "#/$defs/categoryObligation" },
+            "media": { "$ref": "#/$defs/categoryObligation" },
+            "primary_motion": { "$ref": "#/$defs/categoryObligation" },
+            "secondary_motion": { "$ref": "#/$defs/categoryObligation" }
+          },
+          "additionalProperties": false
+        },
         "provenance": { "$ref": "#/$defs/provenance" }
       },
       "additionalProperties": false

--- a/skills/build-resume-portfolio-site/references/design-discovery-schema.json
+++ b/skills/build-resume-portfolio-site/references/design-discovery-schema.json
@@ -38,10 +38,12 @@
         { "$ref": "#/$defs/queryProfile" },
         {
           "type": "object",
-          "required": ["baseline_direction_id", "approved_decision_ids"],
+          "required": ["baseline_direction_id", "approved_decision_ids", "anti_template_baseline_id", "anti_template_terms"],
           "properties": {
             "baseline_direction_id": { "$ref": "#/$defs/nonEmptyString" },
-            "approved_decision_ids": { "$ref": "#/$defs/stringList" }
+            "approved_decision_ids": { "$ref": "#/$defs/stringList" },
+            "anti_template_baseline_id": { "$ref": "#/$defs/nonEmptyString" },
+            "anti_template_terms": { "$ref": "#/$defs/nonEmptyStringList" }
           }
         }
       ],
@@ -92,7 +94,8 @@
       "type": "object",
       "required": [
         "id", "label", "fit", "risks", "tradeoffs", "compatibility",
-        "responsive_fallback", "accessibility_notes", "source_ids"
+        "responsive_fallback", "accessibility_notes", "source_ids",
+        "anti_template_evaluation"
       ],
       "properties": {
         "id": { "$ref": "#/$defs/nonEmptyString" },
@@ -103,7 +106,18 @@
         "compatibility": { "$ref": "#/$defs/stringList" },
         "responsive_fallback": { "$ref": "#/$defs/nonEmptyString" },
         "accessibility_notes": { "$ref": "#/$defs/nonEmptyStringList" },
-        "source_ids": { "$ref": "#/$defs/nonEmptyStringList" }
+        "source_ids": { "$ref": "#/$defs/nonEmptyStringList" },
+        "anti_template_evaluation": {
+          "type": "object",
+          "required": ["baseline_rule_ids", "obligation_ids", "relationship", "rationale"],
+          "properties": {
+            "baseline_rule_ids": { "$ref": "#/$defs/nonEmptyStringList" },
+            "obligation_ids": { "$ref": "#/$defs/nonEmptyStringList" },
+            "relationship": { "enum": ["strengthens", "preserves", "conflicts"] },
+            "rationale": { "$ref": "#/$defs/nonEmptyString" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     },
@@ -202,7 +216,8 @@
       "type": "object",
       "required": [
         "schema_version", "report_type", "category", "query_context",
-        "domains_searched", "inherited_decision_ids", "candidates",
+        "domains_searched", "inherited_decision_ids", "anti_template_baseline_id",
+        "anti_template_rule_ids", "category_obligation_id", "candidates",
         "recommended_candidate_id", "provenance"
       ],
       "properties": {
@@ -214,6 +229,9 @@
         "query_context": { "$ref": "#/$defs/queryContext" },
         "domains_searched": { "$ref": "#/$defs/nonEmptyStringList" },
         "inherited_decision_ids": { "$ref": "#/$defs/stringList" },
+        "anti_template_baseline_id": { "$ref": "#/$defs/nonEmptyString" },
+        "anti_template_rule_ids": { "$ref": "#/$defs/nonEmptyStringList" },
+        "category_obligation_id": { "$ref": "#/$defs/nonEmptyString" },
         "candidates": {
           "type": "array",
           "minItems": 2,

--- a/skills/build-resume-portfolio-site/references/design-intelligence-contract.md
+++ b/skills/build-resume-portfolio-site/references/design-intelligence-contract.md
@@ -18,11 +18,12 @@ Enrichment mode additionally accepts an approved `StyleBrief`. Visible
 reference evidence has priority over Catalog aesthetics. Catalog accessibility,
 responsive, privacy, and implementation guardrails remain mandatory.
 
-Approved-discovery mode consumes the validated baseline, all six validated
-category reports, and the approved site design specification. It copies only
-the candidates selected in the conversation, preserving their report paths and
-catalog source IDs. It is the canonical generation input and cannot recommend a
-different direction or reopen a decision.
+Approved-discovery mode consumes the validated database baseline, the validated
+provisional anti-template baseline, all six validated category reports, and the
+approved site design specification. It copies only the candidates selected in
+the conversation, preserving their report paths, catalog source IDs, and
+anti-template evaluations. It is the canonical generation input and cannot
+recommend a different direction or reopen a decision.
 
 ## Candidate rules
 
@@ -40,6 +41,10 @@ different direction or reopen a decision.
   conversational approval, and verify every selected ID exists in that report.
   A skipped media decision retains its validated report and approval but has no
   selected candidate.
+- Require every category report to reference the same anti-template baseline.
+  A conflicting candidate may be presented as an explicit trade-off but cannot
+  be the default recommendation. Aggregation fails when the trace is missing or
+  inconsistent.
 
 ## Persistence
 
@@ -49,9 +54,16 @@ a temporary sibling file and atomic replacement. Preserve
 when a prototype is rejected.
 
 For integrated generation, write one `approved-discovery` aggregate from the
-persisted baseline and category reports. Do not rerun `recommend`; the aggregate
-preserves the exact approved IDs, selected candidate records, discovery-report
-paths, guardrails, React guidance, and catalog provenance.
+persisted baselines and category reports. Do not rerun `recommend`; the
+aggregate preserves the exact approved IDs, selected candidate records,
+discovery-report paths, anti-template evaluations, guardrails, React guidance,
+and catalog provenance.
+
+Set `anti_template_resolution_required: true`. Creative-direction compilation
+must resolve every provisional rule as `adopted`, `refined`, or
+`rejected_by_approved_choice`, and link that resolution to the approved category
+evidence. A provisional hypothesis is never approval and cannot authorize React
+source edits.
 
 ## Privacy
 

--- a/skills/build-resume-portfolio-site/references/design-intelligence-schema.json
+++ b/skills/build-resume-portfolio-site/references/design-intelligence-schema.json
@@ -26,6 +26,8 @@
     "react_guidelines": {"type": "array", "items": {"type": "string"}},
     "reference_evidence_priority": {"type": "boolean"},
     "baseline": {"type": "object"},
+    "anti_template_baseline": {"type": "object"},
+    "anti_template_resolution_required": {"const": true},
     "approved_decisions": {"$ref": "#/$defs/approvedDecisions"},
     "provenance": {
       "type": "object",
@@ -41,7 +43,7 @@
   "allOf": [
     {
       "if": {"properties": {"mode": {"const": "approved-discovery"}}},
-      "then": {"required": ["baseline", "approved_decisions"]},
+      "then": {"required": ["baseline", "anti_template_baseline", "anti_template_resolution_required", "approved_decisions"]},
       "else": {"required": ["candidate_directions", "selected_direction_id"]}
     }
   ],
@@ -76,7 +78,7 @@
     "discoveryCandidate": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "label", "fit", "risks", "tradeoffs", "compatibility", "responsive_fallback", "accessibility_notes", "source_ids"],
+      "required": ["id", "label", "fit", "risks", "tradeoffs", "compatibility", "responsive_fallback", "accessibility_notes", "source_ids", "anti_template_evaluation"],
       "properties": {
         "id": {"type": "string", "minLength": 1},
         "label": {"type": "string", "minLength": 1},
@@ -86,7 +88,18 @@
         "compatibility": {"type": "array", "items": {"type": "string", "minLength": 1}},
         "responsive_fallback": {"type": "string", "minLength": 1},
         "accessibility_notes": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
-        "source_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+        "source_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "anti_template_evaluation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["baseline_rule_ids", "obligation_ids", "relationship", "rationale"],
+          "properties": {
+            "baseline_rule_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+            "obligation_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+            "relationship": {"enum": ["strengthens", "preserves", "conflicts"]},
+            "rationale": {"type": "string", "minLength": 1}
+          }
+        }
       }
     },
     "approvedDecision": {

--- a/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
+++ b/skills/build-resume-portfolio-site/references/site-brainstorming-contract.md
@@ -8,8 +8,12 @@ visual thesis, interaction architecture, or implementation strategy.
 Inspect approved content, authorized media, references, existing state, and
 confirmed artifacts before asking questions. Build and validate the privacy-safe
 content map, then query the vendored design catalog for a three-direction
-baseline before the first question. Ask one decision-bearing question at a time
-and complete these decisions in order:
+baseline. Before the first question, compile and validate the provisional
+anti-template baseline that states the candidate visual protagonist,
+content-to-form thesis, composition hypothesis, signature devices, template
+independence claim, contextual failure rules, and one obligation per category.
+Ask one decision-bearing question at a time and complete these decisions in
+order:
 
 1. **Overall structure** — composition, hierarchy, navigation, and content density.
 2. **Typography** — type character, scale, rhythm, and reading texture.
@@ -34,8 +38,8 @@ and reduced motion are requirements, not optional style choices.
 For each enabled category:
 
 1. Set `design_<category>_querying`. Query the category's required catalog
-   domains using the baseline plus every prior conversationally approved
-   decision ID. Write and validate
+   domains using the database baseline, the provisional anti-template baseline,
+   and every prior conversationally approved decision ID. Write and validate
    `reports/design-discovery/<category>.json` before showing candidates.
 2. If retrieval returns fewer than two complete candidates or any candidate
    lacks `source_ids`, stop with `design_catalog_insufficient`; do not synthesize
@@ -43,7 +47,10 @@ For each enabled category:
 3. Set `design_<category>_selecting`. Compare two or three materially different candidates, except secondary
    motion may offer more compatible effects without a fixed numeric cap.
 4. Recommend one candidate or compatible set and state fit, risk, trade-offs,
-   compatibility, responsive fallback, accessibility notes, and catalog source IDs.
+   compatibility, responsive fallback, accessibility notes, catalog source IDs,
+   and whether it strengthens, preserves, or conflicts with the anti-template
+   baseline. A conflicting candidate may be shown as a labeled trade-off but
+   cannot be the default recommendation.
 5. Ask whether to open the browser comparison in a separate message before
    requesting a choice for this category.
 6. If accepted, follow `visual-style-preview-contract.md`; if declined, record
@@ -65,15 +72,20 @@ skipped, record the reason and do not offer a media preview.
 The exact domain sequence is structure=`landing/style/product/ux`,
 typography=`typography/style/ux`, color=`color/style/ux`,
 media=`style/product/landing/ux`, primary motion=`motion/style/landing/ux`, and
-secondary motion=`motion/react/ux`. Each query inherits the baseline direction
-and all prior approved decision IDs; it never uses names, contact details, raw
-resume paragraphs, or project secrets.
+secondary motion=`motion/react/ux`. Each query inherits both baselines and all
+prior approved decision IDs; it never uses names, contact details, raw resume
+paragraphs, or project secrets. The provisional baseline has
+`status=provisional_unapproved`: browser activity, preview consent, and the
+artifact itself never select or approve a category.
 
 After final requirements confirmation, write schema-version-3
 `.resume-site-work/reports/site-design-spec.json` and validate it before
 planning. A changed core decision invalidates only downstream category reports,
 final requirements approval, TODO approval, and the implementation plan. Rerun
 those downstream database queries with the revised inherited choices.
+Changing content, audience, the selected baseline direction, visual
+protagonist, or content-to-form thesis invalidates the provisional baseline and
+all six downstream reports.
 
 Do not create or edit React source during discovery or planning.
 

--- a/skills/build-resume-portfolio-site/references/workflow-contract.md
+++ b/skills/build-resume-portfolio-site/references/workflow-contract.md
@@ -15,6 +15,8 @@ content_preflight
 -> content_quality_validating
 -> design_baseline_generating
 -> design_baseline_ready
+-> anti_template_baseline_generating
+-> anti_template_baseline_ready
 -> design_structure_querying -> design_structure_selecting
 -> design_typography_querying -> design_typography_selecting
 -> design_color_querying -> design_color_selecting
@@ -39,10 +41,16 @@ decline affects only that category.
 
 `CONTENT_READY` first creates the privacy-safe content map. Baseline generation
 queries the vendored catalog and must validate before structure querying begins.
-Each category querying state consumes the same baseline plus every prior
-approved decision ID, emits a validated source-linked report, and only then
-enters selection. `design_catalog_insufficient` freezes selection and preserves
-the last valid reports; it never permits fabricated fallback candidates.
+Before structure querying, the anti-template baseline transaction turns the
+selected database direction and privacy-safe content profile into provisional,
+evidence-linked hypotheses for the visual protagonist, content-to-form thesis,
+signature devices, template independence, and six category obligations. It
+must validate with `status=provisional_unapproved`; it is not a selection,
+approval, confirmation gate, or source-edit authorization. Each category
+querying state consumes both baselines plus every prior approved decision ID,
+emits a validated source-linked report, and only then enters selection.
+`design_catalog_insufficient` freezes selection and preserves the last valid
+reports; it never permits fabricated fallback candidates.
 
 Missing or invalid content stays inside this Skill. The bundled content phase
 establishes fact/evidence records, optional JD matching, explicit strategy
@@ -54,6 +62,8 @@ unmatched unless the user supplies evidence; they never become generated facts.
 ```text
 content_copy_waiting_confirmation --approve exact wording--> content_quality_validating
 content_quality_validating --quality and handoff validate--> design_baseline_generating
+design_baseline_ready --provisional baseline validates--> anti_template_baseline_ready
+anti_template_baseline_ready --begin structure retrieval--> design_structure_querying
 content_quality_validating --invalid or copy changes--> content_copy_waiting_confirmation
 ```
 
@@ -80,8 +90,9 @@ returns to the strategy gate without automatic fallback.
 The integrated transaction is the first React generation:
 
 1. Restore the empty/new baseline or the last confirmed artifact for regeneration.
-2. Consume approved content, six decisions, readable TODO plan, JSON plan,
-   design intelligence, creative direction, and authorized-media inventory.
+2. Consume approved content, both discovery baselines, six decisions, readable
+   TODO plan, JSON plan, design intelligence, creative direction, and
+   authorized-media inventory.
 3. Compile and validate `reports/design-contract.json`; this internal artifact
    adds no approval gate and must precede the first React source edit.
 4. Edit only `.resume-site-work/site` and obey the validated design contract.
@@ -116,7 +127,9 @@ A core reversal invalidates that decision's downstream evidence, final
 requirements approval, TODO plan approval, and JSON implementation plan.
 The revised category report and every later category report must be regenerated
 in order so their inherited decision IDs remain truthful. Earlier reports remain
-valid and are not rerun.
+valid and are not rerun. A change to content, audience, selected database
+direction, visual protagonist, or content-to-form thesis invalidates the
+anti-template baseline and every category report.
 
 ## Content preflight
 
@@ -159,7 +172,9 @@ or interaction architecture returns to full discovery.
 Build-state schema version `4` remains active. Older confirmed artifacts may use
 a validated bounded fast-change route. Schema-version-2 design reports remain
 readable evidence but do not satisfy new full discovery; schema-version-1 plans
-do not satisfy TODO plan approval. Never fabricate migrated approvals.
+do not satisfy TODO plan approval. An in-progress discovery without a validated
+anti-template baseline must regenerate from `design_baseline_ready`; never
+fabricate the provisional artifact or migrated approvals.
 
 ## Optional APIHz media transaction
 

--- a/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
+++ b/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
@@ -588,6 +588,7 @@ def search_category(
     category: str,
     content_map: Mapping[str, object],
     baseline: Mapping[str, object],
+    anti_template_baseline: Mapping[str, object],
     decisions: Mapping[str, object],
 ) -> dict[str, object]:
     if category not in CATEGORY_DOMAINS:
@@ -596,10 +597,23 @@ def search_category(
         raise ValueError("content map must be a JSON object")
     if not isinstance(baseline, Mapping):
         raise ValueError("baseline must be a JSON object")
+    if validate_discovery_report(
+        anti_template_baseline, expected_type="anti_template_baseline"
+    ):
+        raise ValueError("anti-template baseline design discovery report is invalid")
     if not isinstance(decisions, Mapping):
         raise ValueError("decisions must be a JSON object")
 
     context = _category_query_context(content_map, baseline, decisions)
+    anti_template_id = _string(anti_template_baseline.get("id"))
+    anti_template_terms = [
+        _string(anti_template_baseline.get("visual_protagonist")),
+        _string(anti_template_baseline.get("content_form_thesis")),
+        _string(anti_template_baseline.get("composition_hypothesis")),
+        _string(anti_template_baseline.get("template_independence_claim")),
+    ]
+    context["anti_template_baseline_id"] = anti_template_id
+    context["anti_template_terms"] = [term for term in anti_template_terms if term]
     inherited_ids = list(context["approved_decision_ids"])
     full_query = _query_text(
         context,
@@ -607,6 +621,7 @@ def search_category(
             [
                 category,
                 _string(context["baseline_direction_id"]),
+                *context["anti_template_terms"],
                 *inherited_ids,
             ]
         ),
@@ -622,6 +637,7 @@ def search_category(
                     _string(context["content_density"]),
                     _string(context["media_profile"]),
                     _string(context["baseline_direction_id"]),
+                    *context["anti_template_terms"],
                     *inherited_ids,
                     category,
                 ),
@@ -634,6 +650,68 @@ def search_category(
             f"category={category}; domains={','.join(CATEGORY_DOMAINS[category])}; "
             f"found={len(candidates)}; required=2"
         )
+    rules = [
+        _mapping(item)
+        for item in _sequence(anti_template_baseline.get("anti_template_rules"))
+    ]
+    rule_ids = [_string(rule.get("id")) for rule in rules if _string(rule.get("id"))]
+    obligation = _mapping(
+        _mapping(anti_template_baseline.get("category_obligations")).get(category)
+    )
+    obligation_id = _string(obligation.get("id"))
+    evaluated_candidates: list[dict[str, object]] = []
+    conflict_markers = (
+        "generic centered",
+        "equal-weight",
+        "decorative-only",
+        "template conflict",
+    )
+    for index, candidate_value in enumerate(candidates):
+        candidate = dict(_mapping(candidate_value))
+        candidate_text = " ".join(
+            _string(item)
+            for field in ("label", "fit", "risks", "tradeoffs")
+            for item in (
+                _sequence(candidate.get(field))
+                if field != "label"
+                else [candidate.get(field)]
+            )
+        ).casefold()
+        if any(marker in candidate_text for marker in conflict_markers):
+            relationship = "conflicts"
+            rationale = _string(obligation.get("avoid"))
+        elif index == 0:
+            relationship = "strengthens"
+            rationale = _string(obligation.get("preserve"))
+        else:
+            relationship = "preserves"
+            rationale = (
+                f"Compatible with {obligation_id}; verify the signature remains "
+                "more prominent than the supporting treatment."
+            )
+        candidate["anti_template_evaluation"] = {
+            "baseline_rule_ids": rule_ids,
+            "obligation_ids": [obligation_id],
+            "relationship": relationship,
+            "rationale": rationale,
+        }
+        evaluated_candidates.append(candidate)
+    recommended = next(
+        (
+            candidate
+            for relationship in ("strengthens", "preserves")
+            for candidate in evaluated_candidates
+            if _mapping(candidate.get("anti_template_evaluation")).get(
+                "relationship"
+            )
+            == relationship
+        ),
+        None,
+    )
+    if recommended is None:
+        raise ValueError(
+            f"anti_template_conflict_all_candidates: category={category}"
+        )
     return {
         "schema_version": 1,
         "report_type": "category",
@@ -641,8 +719,11 @@ def search_category(
         "query_context": context,
         "domains_searched": list(CATEGORY_DOMAINS[category]),
         "inherited_decision_ids": inherited_ids,
-        "candidates": candidates,
-        "recommended_candidate_id": candidates[0]["id"],
+        "anti_template_baseline_id": anti_template_id,
+        "anti_template_rule_ids": rule_ids,
+        "category_obligation_id": obligation_id,
+        "candidates": evaluated_candidates,
+        "recommended_candidate_id": recommended["id"],
         "provenance": {
             "upstream": UPSTREAM,
             "catalog_version": validate_catalog(CATALOG_ROOT).catalog_version,
@@ -653,6 +734,7 @@ def search_category(
 def aggregate_discovery(
     content_map: Mapping[str, object],
     baseline: Mapping[str, object],
+    anti_template_baseline: Mapping[str, object],
     category_reports: Mapping[str, object],
     design_spec: Mapping[str, object],
 ) -> dict[str, object]:
@@ -660,6 +742,11 @@ def aggregate_discovery(
         raise ValueError("content map must be a JSON object")
     if validate_discovery_report(baseline, expected_type="baseline"):
         raise ValueError("baseline design discovery report is invalid")
+    if validate_discovery_report(
+        anti_template_baseline, expected_type="anti_template_baseline"
+    ):
+        raise ValueError("anti-template baseline design discovery report is invalid")
+    anti_template_id = _string(anti_template_baseline.get("id"))
     decisions = _mapping(design_spec.get("decisions"))
     approved_decisions: dict[str, object] = {}
     for category in CATEGORY_DOMAINS:
@@ -667,6 +754,8 @@ def aggregate_discovery(
         errors = validate_discovery_report(report, expected_type="category")
         if errors or report.get("category") != category:
             raise ValueError(f"invalid category report: {category}")
+        if report.get("anti_template_baseline_id") != anti_template_id:
+            raise ValueError(f"anti-template baseline mismatch: {category}")
         decision = _mapping(decisions.get(category))
         approval = _mapping(decision.get("approval"))
         if approval.get("status") != "user_approved":
@@ -705,6 +794,8 @@ def aggregate_discovery(
         "mode": "approved-discovery",
         "query": _content_profile(content_map),
         "baseline": dict(baseline),
+        "anti_template_baseline": dict(anti_template_baseline),
+        "anti_template_resolution_required": True,
         "approved_decisions": approved_decisions,
         "guardrails": list(_sequence(baseline.get("guardrails"))),
         "react_guidelines": list(
@@ -814,11 +905,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     category_parser.add_argument("--content-map", type=Path, required=True)
     category_parser.add_argument("--baseline", type=Path, required=True)
+    category_parser.add_argument(
+        "--anti-template-baseline", type=Path, required=True
+    )
     category_parser.add_argument("--decisions", type=Path, required=True)
     category_parser.add_argument("--output", type=Path, required=True)
     aggregate_parser = subparsers.add_parser("aggregate")
     aggregate_parser.add_argument("--content-map", type=Path, required=True)
     aggregate_parser.add_argument("--baseline", type=Path, required=True)
+    aggregate_parser.add_argument(
+        "--anti-template-baseline", type=Path, required=True
+    )
     aggregate_parser.add_argument("--reports-dir", type=Path, required=True)
     aggregate_parser.add_argument("--site-design-spec", type=Path, required=True)
     aggregate_parser.add_argument("--output", type=Path, required=True)
@@ -851,6 +948,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.category,
                 _read_json_object(args.content_map, "content map"),
                 _read_json_object(args.baseline, "baseline"),
+                _read_json_object(
+                    args.anti_template_baseline, "anti-template baseline"
+                ),
                 _read_json_object(args.decisions, "decisions"),
             )
         else:
@@ -864,6 +964,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = aggregate_discovery(
                 _read_json_object(args.content_map, "content map"),
                 _read_json_object(args.baseline, "baseline"),
+                _read_json_object(
+                    args.anti_template_baseline, "anti-template baseline"
+                ),
                 reports,
                 _read_json_object(args.site_design_spec, "site design spec"),
             )

--- a/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
+++ b/skills/build-resume-portfolio-site/scripts/portfolio_design_search.py
@@ -360,6 +360,146 @@ def build_baseline(
     return report
 
 
+def build_anti_template_baseline(
+    content_map: Mapping[str, object],
+    baseline: Mapping[str, object],
+) -> dict[str, object]:
+    if not isinstance(content_map, Mapping):
+        raise ValueError("content map must be a JSON object")
+    if validate_discovery_report(baseline, expected_type="baseline"):
+        raise ValueError("baseline design discovery report is invalid")
+
+    selected_id = _string(baseline.get("selected_direction_id"))
+    selected = next(
+        (
+            _mapping(item)
+            for item in _sequence(baseline.get("candidate_directions"))
+            if _string(_mapping(item).get("id")) == selected_id
+        ),
+        {},
+    )
+    if not selected:
+        raise ValueError("selected baseline direction is missing")
+
+    profile = _content_profile(content_map)
+    evidence_ids = _unique_tokens(
+        [
+            *(
+                _string(item)
+                for item in _sequence(selected.get("source_ids"))
+                if _string(item)
+            ),
+            *(
+                _string(item)
+                for item in _sequence(baseline.get("reference_selection_ids"))
+                if _string(item)
+            ),
+            "content-map:profile.role",
+            "content-map:profile.industry",
+            "content-map:projects",
+            "content-map:skills",
+        ],
+        limit=24,
+    )
+    style_family = _string(selected.get("style_family"), "content-led")
+    composition = _string(
+        selected.get("composition"), "asymmetric evidence-led narrative"
+    )
+    role = _string(profile.get("role"), "portfolio professional")
+    protagonist = (
+        f"The evidence-backed project progression of this {role}, rather than "
+        "a generic profile introduction."
+    )
+    content_form_thesis = (
+        f"Use {composition} to make project decisions, scope, and outcomes carry "
+        "the hierarchy instead of flattening unrelated evidence into equal cards."
+    )
+    rules = [
+        {
+            "id": "anti-template.no-equal-card-grid",
+            "criterion": (
+                "Do not flatten unrelated experience, project, and skill evidence "
+                "into repeated equal-weight cards."
+            ),
+            "evidence_ids": evidence_ids,
+        },
+        {
+            "id": "anti-template.signature-remains-visible",
+            "criterion": (
+                "Keep the approved evidence-led protagonist and a recognizable "
+                "structural device visible across responsive layouts."
+            ),
+            "evidence_ids": evidence_ids,
+        },
+        {
+            "id": "anti-template.effects-have-purpose",
+            "criterion": (
+                "Use surface and motion effects only when they clarify content, "
+                "hierarchy, interaction, or navigation."
+            ),
+            "evidence_ids": evidence_ids,
+        },
+    ]
+    obligation_text = {
+        "structure": (
+            "Preserve the evidence-led protagonist in an identifiable composition.",
+            "Avoid a generic centered hero followed by an equal card grid.",
+        ),
+        "typography": (
+            "Give project decisions and outcomes a distinctive hierarchy.",
+            "Avoid one interchangeable scale for every content type.",
+        ),
+        "color": (
+            "Use color to reinforce evidence priority and the signature device.",
+            "Avoid distributing gradients, glow, or accent color uniformly.",
+        ),
+        "media": (
+            "Give authorized evidence one clear narrative role.",
+            "Avoid decorative stock imagery or repeated placeholder treatments.",
+        ),
+        "primary_motion": (
+            "Tie the primary motion system to narrative progression or navigation.",
+            "Avoid a generic reveal effect applied to every section.",
+        ),
+        "secondary_motion": (
+            "Use secondary effects to explain state, hierarchy, or affordance.",
+            "Avoid decorative motion that competes with the primary system.",
+        ),
+    }
+    obligations = {
+        category: {
+            "id": f"anti-template-obligation.{category}",
+            "preserve": texts[0],
+            "avoid": texts[1],
+            "evidence_ids": evidence_ids,
+        }
+        for category, texts in obligation_text.items()
+    }
+    return {
+        "schema_version": 1,
+        "id": f"anti-template-baseline:{selected_id}",
+        "report_type": "anti_template_baseline",
+        "mode": "anti-template-baseline",
+        "status": "provisional_unapproved",
+        "query_context": profile,
+        "evidence_ids": evidence_ids,
+        "visual_protagonist": protagonist,
+        "content_form_thesis": content_form_thesis,
+        "composition_hypothesis": composition,
+        "signature_device_candidates": [
+            f"A persistent project-evidence index shaped by {composition}",
+            f"A {style_family} hierarchy that exposes decisions before decoration",
+        ],
+        "template_independence_claim": (
+            f"The direction is project-specific because {role} evidence controls "
+            f"the {style_family} composition, hierarchy, and interaction choices."
+        ),
+        "anti_template_rules": rules,
+        "category_obligations": obligations,
+        "provenance": dict(_mapping(baseline.get("provenance"))),
+    }
+
+
 def _row_label(domain: str, row: Mapping[str, object]) -> str:
     return _string(row.get(DOMAIN_ID_KEYS[domain]), domain)
 
@@ -664,6 +804,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     baseline_parser.add_argument("--content-map", type=Path, required=True)
     baseline_parser.add_argument("--reference-selection", type=Path)
     baseline_parser.add_argument("--output", type=Path, required=True)
+    anti_template_parser = subparsers.add_parser("anti-template-baseline")
+    anti_template_parser.add_argument("--content-map", type=Path, required=True)
+    anti_template_parser.add_argument("--baseline", type=Path, required=True)
+    anti_template_parser.add_argument("--output", type=Path, required=True)
     category_parser = subparsers.add_parser("category")
     category_parser.add_argument(
         "--category", choices=tuple(CATEGORY_DOMAINS), required=True
@@ -696,6 +840,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = build_baseline(
                 _read_json_object(args.content_map, "content map"),
                 reference_selection,
+            )
+        elif args.command == "anti-template-baseline":
+            result = build_anti_template_baseline(
+                _read_json_object(args.content_map, "content map"),
+                _read_json_object(args.baseline, "baseline"),
             )
         elif args.command == "category":
             result = search_category(

--- a/skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
+++ b/skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import portfolio_design_search as search  # noqa: E402
+import validate_design_discovery as discovery_validator  # noqa: E402
+
+
+def _direction(index: int) -> dict[str, object]:
+    return {
+        "id": f"direction-{index}",
+        "name": f"Direction {index}",
+        "style_family": "editorial" if index == 1 else f"family-{index}",
+        "composition": "asymmetric project narrative",
+        "color_relationships": ["primary: #111111", "accent: #ff5a36"],
+        "typography_roles": {
+            "display": "editorial display",
+            "body": "readable sans",
+            "hierarchy": "strong numbered hierarchy",
+        },
+        "surface_language": "flat high-contrast surfaces",
+        "media_strategy": "Use authorized project evidence as the visual lead.",
+        "fit_reasons": ["Fits a project-led technical portfolio."],
+        "risks": ["Avoid equal-weight project cards."],
+        "source_ids": [
+            f"style:editorial-{index}",
+            f"landing:project-story-{index}",
+        ],
+    }
+
+
+def _baseline() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "report_type": "baseline",
+        "mode": "baseline",
+        "query": {
+            "role": "frontend engineer",
+            "industry": "developer tools",
+            "content_density": "high",
+            "media_profile": "limited",
+            "keywords": ["React", "design systems"],
+        },
+        "candidate_directions": [_direction(1), _direction(2), _direction(3)],
+        "selected_direction_id": "direction-1",
+        "guardrails": ["Preserve readable hierarchy."],
+        "react_guidelines": ["Keep component ownership explicit."],
+        "reference_selection_ids": ["reference:project-process"],
+        "provenance": {
+            "upstream": "nextlevelbuilder/ui-ux-pro-max-skill",
+            "catalog_version": "test-catalog",
+        },
+    }
+
+
+def _content_map() -> dict[str, object]:
+    return {
+        "profile": {
+            "role": "frontend engineer",
+            "industry": "developer tools",
+        },
+        "projects": [
+            {"domain": "design systems", "technologies": ["React", "CSS"]}
+        ],
+        "skills": ["interaction design", "accessibility"],
+        "media": {"project_images": 1},
+    }
+
+
+class EarlyAntiTemplateBaselineTests(unittest.TestCase):
+    def test_builds_valid_provisional_baseline(self) -> None:
+        report = search.build_anti_template_baseline(_content_map(), _baseline())
+
+        self.assertEqual(report["report_type"], "anti_template_baseline")
+        self.assertEqual(report["status"], "provisional_unapproved")
+        self.assertTrue(report["evidence_ids"])
+        self.assertEqual(
+            set(report["category_obligations"]), set(search.CATEGORY_DOMAINS)
+        )
+        self.assertEqual(
+            discovery_validator.validate(report, "anti_template_baseline"), []
+        )
+
+    def test_rejects_missing_evidence(self) -> None:
+        report = search.build_anti_template_baseline(_content_map(), _baseline())
+        invalid = copy.deepcopy(report)
+        invalid["evidence_ids"] = []
+
+        self.assertIn(
+            "anti-template baseline requires evidence_ids",
+            discovery_validator.validate(invalid, "anti_template_baseline"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
+++ b/skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
@@ -8,10 +8,12 @@ from unittest.mock import patch
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPTS_DIR.parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 import portfolio_design_search as search  # noqa: E402
+import validate_creative_direction as creative_validator  # noqa: E402
 import validate_design_discovery as discovery_validator  # noqa: E402
 
 
@@ -104,6 +106,74 @@ def _approved_design_spec() -> dict[str, object]:
             }
             for category in search.CATEGORY_DOMAINS
         }
+    }
+
+
+def _creative_direction() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "creative_thesis": "Project decisions become the visible design system.",
+        "experience_priority": ["Project evidence", "Engineering judgment"],
+        "creative_freedom": {
+            "fixed": ["Preserve approved project evidence"],
+            "open": {
+                "composition": ["Asymmetric evidence narrative"],
+                "layout_patterns": ["Persistent project index"],
+                "motion_language": ["Progressive narrative motion"],
+                "visual_metaphor": ["Decision trail"],
+                "surface_treatment": ["High-contrast editorial surfaces"],
+            },
+            "avoid": ["Equal-weight generic cards"],
+        },
+        "layout_candidates": [
+            {
+                "id": "layout-1",
+                "family": "editorial",
+                "fit": "Makes evidence primary.",
+                "risks": ["Needs careful mobile ordering."],
+                "responsive_fallback": "Keep the project index before details.",
+            },
+            {
+                "id": "layout-2",
+                "family": "split narrative",
+                "fit": "Separates decisions from results.",
+                "risks": ["May require more scrolling."],
+                "responsive_fallback": "Stack paired evidence in semantic order.",
+            },
+        ],
+        "selected_candidate_id": "layout-1",
+        "selection_rationale": "Best preserves the approved evidence hierarchy.",
+        "concept_prototype": {
+            "visual_protagonist": "The project decision trail.",
+            "composition_commitment": "An asymmetric indexed narrative.",
+            "type_color_character": "Editorial contrast with restrained accent.",
+            "representative_interaction_state": "Active project index state.",
+            "template_independence_test": "The index remains recognizable without motion.",
+            "deferred_to_later": ["Final media crop details"],
+        },
+        "responsive_freedom": {
+            "must_preserve": ["Project index prominence"],
+            "may_adapt": ["Column count"],
+        },
+        "motion_freedom": {
+            "purpose": "Reveal causal project progression.",
+            "allowed": ["Index-linked transitions"],
+            "avoid": ["Uniform section reveals"],
+        },
+        "review_questions": [
+            "Is the project evidence dominant?",
+            "Does the index remain recognizable?",
+            "Does motion clarify progression?",
+        ],
+        "anti_template_resolutions": [
+            {
+                "rule_id": "anti-template.no-equal-card-grid",
+                "status": "adopted",
+                "approved_candidate_ids": ["structure-1"],
+                "evidence_ids": ["style:editorial-1"],
+                "rationale": "The approved structure uses unequal evidence hierarchy.",
+            }
+        ],
     }
 
 
@@ -238,6 +308,64 @@ class EarlyAntiTemplateBaselineTests(unittest.TestCase):
                 mismatched,
                 _approved_design_spec(),
             )
+
+    def test_skill_generates_anti_template_baseline_before_structure(self) -> None:
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8").replace(
+            "\r\n", "\n"
+        )
+        creative_contract = (
+            SKILL_ROOT / "references" / "creative-direction-contract.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertLess(
+            skill.index("anti_template_baseline_generating"),
+            skill.index("--category structure"),
+        )
+        self.assertIn(
+            'anti-template-baseline.json" `\n  --expected-type anti_template_baseline',
+            skill,
+        )
+        self.assertGreaterEqual(skill.count("--anti-template-baseline"), 7)
+        self.assertIn("provisional_unapproved", creative_contract)
+        self.assertIn(
+            "The provisional baseline is not approval", skill
+        )
+        self.assertIn(
+            "Browser preview and user choice remain per-category approvals", skill
+        )
+
+    def test_creative_direction_requires_resolved_anti_template_rules(self) -> None:
+        report = _creative_direction()
+        expected_rules = {"anti-template.no-equal-card-grid"}
+        self.assertEqual(
+            creative_validator.validate(report, expected_rule_ids=expected_rules), []
+        )
+
+        missing = copy.deepcopy(report)
+        del missing["anti_template_resolutions"]
+        self.assertIn(
+            "missing root fields: anti_template_resolutions",
+            creative_validator.validate(missing, expected_rule_ids=expected_rules),
+        )
+
+        invalid = copy.deepcopy(report)
+        invalid["anti_template_resolutions"][0]["status"] = "unreviewed"
+        self.assertIn(
+            "anti_template_resolutions[0] has invalid status",
+            creative_validator.validate(invalid, expected_rule_ids=expected_rules),
+        )
+
+        incomplete = copy.deepcopy(report)
+        self.assertIn(
+            "anti-template resolutions do not match provisional rules",
+            creative_validator.validate(
+                incomplete,
+                expected_rule_ids={
+                    "anti-template.no-equal-card-grid",
+                    "anti-template.signature-remains-visible",
+                },
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
+++ b/skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py
@@ -4,6 +4,7 @@ import copy
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
@@ -75,6 +76,37 @@ def _content_map() -> dict[str, object]:
     }
 
 
+def _candidate(category: str, index: int) -> dict[str, object]:
+    return {
+        "id": f"{category}-{index}",
+        "label": f"{category.title()} option {index}",
+        "fit": ["Strengthens the evidence-led hierarchy."],
+        "risks": ["Requires responsive verification."],
+        "tradeoffs": ["Balances expression and readability."],
+        "compatibility": [],
+        "responsive_fallback": "Preserve semantic order in one column.",
+        "accessibility_notes": ["Preserve focus and reduced motion."],
+        "source_ids": [f"style:{category}-{index}"],
+    }
+
+
+def _approved_design_spec() -> dict[str, object]:
+    return {
+        "decisions": {
+            category: {
+                "status": "confirmed",
+                "selected_candidate_ids": [f"{category}-1"],
+                "discovery_report": (
+                    ".resume-site-work/reports/design-discovery/"
+                    f"{category.replace('_', '-')}.json"
+                ),
+                "approval": {"status": "user_approved"},
+            }
+            for category in search.CATEGORY_DOMAINS
+        }
+    }
+
+
 class EarlyAntiTemplateBaselineTests(unittest.TestCase):
     def test_builds_valid_provisional_baseline(self) -> None:
         report = search.build_anti_template_baseline(_content_map(), _baseline())
@@ -98,6 +130,114 @@ class EarlyAntiTemplateBaselineTests(unittest.TestCase):
             "anti-template baseline requires evidence_ids",
             discovery_validator.validate(invalid, "anti_template_baseline"),
         )
+
+    def test_category_inherits_anti_template_rules_and_obligation(self) -> None:
+        anti_template = search.build_anti_template_baseline(
+            _content_map(), _baseline()
+        )
+        with patch.object(
+            search,
+            "_category_candidates",
+            return_value=[_candidate("structure", 1), _candidate("structure", 2)],
+        ):
+            report = search.search_category(
+                "structure", _content_map(), _baseline(), anti_template, {}
+            )
+
+        self.assertEqual(
+            report["anti_template_baseline_id"], anti_template["id"]
+        )
+        self.assertTrue(
+            report["candidates"][0]["anti_template_evaluation"][
+                "baseline_rule_ids"
+            ]
+        )
+        self.assertEqual(discovery_validator.validate(report, "category"), [])
+
+    def test_category_validation_rejects_broken_traceability(self) -> None:
+        anti_template = search.build_anti_template_baseline(
+            _content_map(), _baseline()
+        )
+        with patch.object(
+            search,
+            "_category_candidates",
+            return_value=[_candidate("color", 1), _candidate("color", 2)],
+        ):
+            report = search.search_category(
+                "color", _content_map(), _baseline(), anti_template, {}
+            )
+
+        missing_id = copy.deepcopy(report)
+        missing_id["anti_template_baseline_id"] = ""
+        self.assertIn(
+            "category requires anti_template_baseline_id",
+            discovery_validator.validate(missing_id, "category"),
+        )
+
+        unknown_rule = copy.deepcopy(report)
+        unknown_rule["candidates"][0]["anti_template_evaluation"][
+            "baseline_rule_ids"
+        ] = ["anti-template.unknown"]
+        self.assertIn(
+            "candidate color-1 references unknown anti-template rules",
+            discovery_validator.validate(unknown_rule, "category"),
+        )
+
+        missing_obligation = copy.deepcopy(report)
+        missing_obligation["candidates"][0]["anti_template_evaluation"][
+            "obligation_ids"
+        ] = []
+        self.assertIn(
+            "candidate color-1 must reference the category obligation",
+            discovery_validator.validate(missing_obligation, "category"),
+        )
+
+        invalid_relationship = copy.deepcopy(report)
+        invalid_relationship["candidates"][0]["anti_template_evaluation"][
+            "relationship"
+        ] = "decorates"
+        self.assertIn(
+            "candidate color-1 has invalid anti-template relationship",
+            discovery_validator.validate(invalid_relationship, "category"),
+        )
+
+    def test_aggregate_requires_one_anti_template_baseline(self) -> None:
+        anti_template = search.build_anti_template_baseline(
+            _content_map(), _baseline()
+        )
+        reports: dict[str, object] = {}
+        for category in search.CATEGORY_DOMAINS:
+            with patch.object(
+                search,
+                "_category_candidates",
+                return_value=[_candidate(category, 1), _candidate(category, 2)],
+            ):
+                reports[category] = search.search_category(
+                    category, _content_map(), _baseline(), anti_template, {}
+                )
+
+        aggregate = search.aggregate_discovery(
+            _content_map(),
+            _baseline(),
+            anti_template,
+            reports,
+            _approved_design_spec(),
+        )
+        self.assertEqual(aggregate["anti_template_baseline"], anti_template)
+        self.assertIs(aggregate["anti_template_resolution_required"], True)
+
+        mismatched = copy.deepcopy(reports)
+        mismatched["secondary_motion"]["anti_template_baseline_id"] = (
+            "anti-template-baseline:other"
+        )
+        with self.assertRaisesRegex(ValueError, "anti-template baseline mismatch"):
+            search.aggregate_discovery(
+                _content_map(),
+                _baseline(),
+                anti_template,
+                mismatched,
+                _approved_design_spec(),
+            )
 
 
 if __name__ == "__main__":

--- a/skills/build-resume-portfolio-site/scripts/validate_creative_direction.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_creative_direction.py
@@ -20,6 +20,7 @@ ROOT_FIELDS = {
     "responsive_freedom",
     "motion_freedom",
     "review_questions",
+    "anti_template_resolutions",
 }
 OPEN_FIELDS = {
     "composition",
@@ -95,7 +96,9 @@ def _walk(value: Any, path: str = "$") -> list[tuple[str, Any]]:
     return items
 
 
-def validate(report: Any) -> list[str]:
+def validate(
+    report: Any, expected_rule_ids: set[str] | None = None
+) -> list[str]:
     errors: list[str] = []
     if not isinstance(report, dict):
         return ["report must be a JSON object"]
@@ -113,6 +116,59 @@ def validate(report: Any) -> list[str]:
         errors.append("selection_rationale must be a non-empty string")
     if not _string_list(report["review_questions"], minimum=3):
         errors.append("review_questions needs at least three unique entries")
+
+    resolutions = report["anti_template_resolutions"]
+    resolution_rule_ids: set[str] = set()
+    if not isinstance(resolutions, list) or not resolutions:
+        errors.append("anti_template_resolutions must be a non-empty list")
+    else:
+        required_resolution_fields = {
+            "rule_id",
+            "status",
+            "approved_candidate_ids",
+            "evidence_ids",
+            "rationale",
+        }
+        for index, resolution in enumerate(resolutions):
+            if not isinstance(resolution, dict) or set(resolution) != required_resolution_fields:
+                errors.append(
+                    f"anti_template_resolutions[{index}] has invalid fields"
+                )
+                continue
+            rule_id = resolution["rule_id"]
+            if not _string(rule_id):
+                errors.append(
+                    f"anti_template_resolutions[{index}] requires rule_id"
+                )
+            elif rule_id in resolution_rule_ids:
+                errors.append(f"duplicate anti-template resolution: {rule_id}")
+            else:
+                resolution_rule_ids.add(rule_id)
+            if resolution["status"] not in {
+                "adopted",
+                "refined",
+                "rejected_by_approved_choice",
+            }:
+                errors.append(
+                    f"anti_template_resolutions[{index}] has invalid status"
+                )
+            if not _string_list(resolution["approved_candidate_ids"]):
+                errors.append(
+                    f"anti_template_resolutions[{index}] requires approved_candidate_ids"
+                )
+            if not _string_list(resolution["evidence_ids"]):
+                errors.append(
+                    f"anti_template_resolutions[{index}] requires evidence_ids"
+                )
+            if not _string(resolution["rationale"]):
+                errors.append(
+                    f"anti_template_resolutions[{index}] requires rationale"
+                )
+    if (
+        expected_rule_ids is not None
+        and resolution_rule_ids != expected_rule_ids
+    ):
+        errors.append("anti-template resolutions do not match provisional rules")
 
     freedom = report["creative_freedom"]
     fixed: list[str] = []
@@ -259,6 +315,7 @@ def main() -> int:
         description="Validate a portfolio creative-direction report."
     )
     parser.add_argument("report", type=Path)
+    parser.add_argument("--design-intelligence", type=Path)
     args = parser.parse_args()
     try:
         payload = json.loads(args.report.read_text(encoding="utf-8"))
@@ -269,7 +326,27 @@ def main() -> int:
         print(f"ERROR: could not read report: {exc}")
         return 1
 
-    errors = validate(payload)
+    expected_rule_ids: set[str] | None = None
+    if args.design_intelligence:
+        try:
+            design_intelligence = json.loads(
+                args.design_intelligence.read_text(encoding="utf-8")
+            )
+            rules = design_intelligence["anti_template_baseline"][
+                "anti_template_rules"
+            ]
+            expected_rule_ids = {
+                item["id"]
+                for item in rules
+                if isinstance(item, dict) and _string(item.get("id"))
+            }
+            if not expected_rule_ids:
+                raise ValueError("anti-template rules are empty")
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            print(f"ERROR: could not read design intelligence: {exc}")
+            return 1
+
+    errors = validate(payload, expected_rule_ids=expected_rule_ids)
     if errors:
         for error in errors:
             print(f"ERROR: {error}")

--- a/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
@@ -146,6 +146,17 @@ def _validate_category(payload: dict[str, Any]) -> list[str]:
     if not _strings(inherited):
         errors.append("inherited_decision_ids must be a string list")
 
+    baseline_id = payload.get("anti_template_baseline_id")
+    if not _string(baseline_id):
+        errors.append("category requires anti_template_baseline_id")
+    known_rule_ids = payload.get("anti_template_rule_ids")
+    if not _strings(known_rule_ids, non_empty=True):
+        errors.append("category requires anti_template_rule_ids")
+        known_rule_ids = []
+    obligation_id = payload.get("category_obligation_id")
+    if not _string(obligation_id):
+        errors.append("category requires category_obligation_id")
+
     candidates = payload.get("candidates")
     if not isinstance(candidates, list) or len(candidates) < 2:
         errors.append("category requires at least two candidates")
@@ -173,6 +184,39 @@ def _validate_category(payload: dict[str, Any]) -> list[str]:
             errors.append(f"candidate {candidate_id} compatibility must be a string list")
         if not _string(candidate.get("responsive_fallback")):
             errors.append(f"candidate {candidate_id} requires responsive_fallback")
+        evaluation = candidate.get("anti_template_evaluation")
+        if not isinstance(evaluation, dict):
+            errors.append(
+                f"candidate {candidate_id} requires anti_template_evaluation"
+            )
+            continue
+        candidate_rule_ids = evaluation.get("baseline_rule_ids")
+        if not _strings(candidate_rule_ids, non_empty=True) or not set(
+            candidate_rule_ids
+        ) <= set(known_rule_ids):
+            errors.append(
+                f"candidate {candidate_id} references unknown anti-template rules"
+            )
+        obligation_ids = evaluation.get("obligation_ids")
+        if (
+            not _strings(obligation_ids, non_empty=True)
+            or obligation_id not in obligation_ids
+        ):
+            errors.append(
+                f"candidate {candidate_id} must reference the category obligation"
+            )
+        if evaluation.get("relationship") not in {
+            "strengthens",
+            "preserves",
+            "conflicts",
+        }:
+            errors.append(
+                f"candidate {candidate_id} has invalid anti-template relationship"
+            )
+        if not _string(evaluation.get("rationale")):
+            errors.append(
+                f"candidate {candidate_id} requires anti-template rationale"
+            )
     if len(ids) != len(set(ids)):
         errors.append("candidate IDs must be unique")
     if payload.get("recommended_candidate_id") not in ids:

--- a/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_design_discovery.py
@@ -51,6 +51,12 @@ CANDIDATE_LIST_FIELDS = (
     "accessibility_notes",
     "source_ids",
 )
+ANTI_TEMPLATE_TEXT_FIELDS = (
+    "visual_protagonist",
+    "content_form_thesis",
+    "composition_hypothesis",
+    "template_independence_claim",
+)
 
 
 def _string(value: Any) -> bool:
@@ -175,6 +181,70 @@ def _validate_category(payload: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_anti_template_baseline(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("mode") != "anti-template-baseline":
+        errors.append("anti-template baseline mode must be anti-template-baseline")
+    if payload.get("status") != "provisional_unapproved":
+        errors.append("anti-template baseline must remain provisional_unapproved")
+    if not _string(payload.get("id")):
+        errors.append("anti-template baseline requires an ID")
+    if not _strings(payload.get("evidence_ids"), non_empty=True):
+        errors.append("anti-template baseline requires evidence_ids")
+    for field in ANTI_TEMPLATE_TEXT_FIELDS:
+        if not _string(payload.get(field)):
+            errors.append(f"anti-template baseline requires {field}")
+    if not _strings(payload.get("signature_device_candidates"), non_empty=True):
+        errors.append("anti-template baseline requires signature_device_candidates")
+
+    rules = payload.get("anti_template_rules")
+    if not isinstance(rules, list) or not rules:
+        errors.append("anti-template baseline requires anti_template_rules")
+        rules = []
+    rule_ids: list[str] = []
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            errors.append(f"anti-template rule[{index}] must be an object")
+            continue
+        rule_id = rule.get("id")
+        if not _string(rule_id):
+            errors.append(f"anti-template rule[{index}] requires an ID")
+        else:
+            rule_ids.append(rule_id)
+        if not _string(rule.get("criterion")):
+            errors.append(f"anti-template rule {rule_id or index} requires criterion")
+        if not _strings(rule.get("evidence_ids"), non_empty=True):
+            errors.append(
+                f"anti-template rule {rule_id or index} requires evidence_ids"
+            )
+    if len(rule_ids) != len(set(rule_ids)):
+        errors.append("anti-template rule IDs must be unique")
+
+    obligations = payload.get("category_obligations")
+    if not isinstance(obligations, dict) or set(obligations) != set(EXPECTED_DOMAINS):
+        errors.append("anti-template baseline requires exactly six category obligations")
+        obligations = {}
+    obligation_ids: list[str] = []
+    for category, obligation in obligations.items():
+        if not isinstance(obligation, dict):
+            errors.append(f"category obligation {category} must be an object")
+            continue
+        obligation_id = obligation.get("id")
+        if not _string(obligation_id):
+            errors.append(f"category obligation {category} requires an ID")
+        else:
+            obligation_ids.append(obligation_id)
+        for field in ("preserve", "avoid"):
+            if not _string(obligation.get(field)):
+                errors.append(f"category obligation {category} requires {field}")
+        if not _strings(obligation.get("evidence_ids"), non_empty=True):
+            errors.append(f"category obligation {category} requires evidence_ids")
+    if len(obligation_ids) != len(set(obligation_ids)):
+        errors.append("category obligation IDs must be unique")
+    errors.extend(_validate_provenance(payload.get("provenance")))
+    return errors
+
+
 def validate(payload: Any, expected_type: str | None = None) -> list[str]:
     if not isinstance(payload, dict):
         return ["design discovery report must be an object"]
@@ -191,10 +261,14 @@ def validate(payload: Any, expected_type: str | None = None) -> list[str]:
     errors.extend(_privacy_errors(query_payload, {"name"}))
     if report_type == "baseline":
         errors.extend(_validate_baseline(payload))
+    elif report_type == "anti_template_baseline":
+        errors.extend(_validate_anti_template_baseline(payload))
     elif report_type == "category":
         errors.extend(_validate_category(payload))
     else:
-        errors.append("report_type must be baseline or category")
+        errors.append(
+            "report_type must be baseline, anti_template_baseline, or category"
+        )
     return errors
 
 
@@ -203,7 +277,10 @@ def main() -> int:
         description="Validate a database-first design discovery report."
     )
     parser.add_argument("report", type=Path)
-    parser.add_argument("--expected-type", choices=("baseline", "category"))
+    parser.add_argument(
+        "--expected-type",
+        choices=("baseline", "anti_template_baseline", "category"),
+    )
     args = parser.parse_args()
     try:
         payload = json.loads(args.report.read_text(encoding="utf-8"))

--- a/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
+++ b/skills/build-resume-portfolio-site/scripts/validate_skill_resources.py
@@ -52,10 +52,13 @@ VISUAL_COMPANION_FILES = (
 )
 
 AESTHETIC_QUALITY_FILES = (
+    "references/creative-direction-contract.md",
+    "references/creative-direction-schema.json",
     "references/design-contract.md",
     "references/design-contract-schema.json",
     "references/visual-audit-schema.json",
     "scripts/validate_design_contract.py",
+    "scripts/validate_creative_direction.py",
     "scripts/validate_visual_audit.py",
 )
 
@@ -95,6 +98,21 @@ DESIGN_DISCOVERY_FILES = (
     "scripts/validate_design_discovery.py",
     "scripts/portfolio_design_search.py",
 )
+DESIGN_DISCOVERY_REQUIRED_MARKERS = {
+    "references/design-discovery-schema.json": (
+        '"anti_template_baseline"',
+        '"antiTemplateBaseline"',
+    ),
+    "scripts/validate_design_discovery.py": (
+        '"anti_template_baseline"',
+        "_validate_anti_template_baseline",
+    ),
+    "scripts/portfolio_design_search.py": (
+        "build_anti_template_baseline",
+        'add_parser("anti-template-baseline")',
+        '"--anti-template-baseline"',
+    ),
+}
 
 STAGE_RESOURCES = {
     "content-preparation": ("content-workflow",),
@@ -390,6 +408,14 @@ def validate_resources(skill_root: Path, mode: str, stage: str | None, workspace
                         resource_errors.append(
                             f"invalid_design_discovery_file: {relative}"
                         )
+                    for marker in DESIGN_DISCOVERY_REQUIRED_MARKERS.get(
+                        relative, ()
+                    ):
+                        if marker not in text:
+                            resource_errors.append(
+                                "missing_design_discovery_marker: "
+                                f"{relative}: {marker}"
+                            )
                 except (OSError, UnicodeError, json.JSONDecodeError) as error:
                     resource_errors.append(
                         f"invalid_design_discovery_file: {relative}: {error}"


### PR DESCRIPTION
## 变更内容

- 在六项视觉选择前生成并验证 `anti-template-baseline.json`
- 让结构、字体、配色、媒体、主动效和副动效候选继承同一反模板基线
- 为候选记录 `strengthens / preserves / conflicts`，禁止默认推荐冲突候选
- 在聚合与 creative direction 阶段强制解析全部临时反模板规则
- 更新 Skill 工作流、Schema、验证器、资源契约和回归测试

## 原因

此前设计数据库虽然在首个问题前介入，但视觉主角、内容—形式关系、结构签名和反模板规则主要到六项选择完成后才编译，可能导致各项选择单独合理、组合后仍趋于模板化。

## 用户影响

反模板设计主线现在会在第一次视觉选择前形成，并约束后续六项检索；用户仍逐项选择和批准，临时基线本身不具有批准语义，也不能授权生成 React 源码。

## 验证

- `python -m unittest skills/build-resume-portfolio-site/scripts/test_early_anti_template_baseline.py -v`：7 项通过
- discovery 资源校验通过
- integrated 资源校验通过
- Python compileall 与 JSON Schema 语法检查通过
- 源码和全局安装版 107 个文件 SHA-256 一致